### PR TITLE
'@' not supported in path

### DIFF
--- a/test/additional-tests.txt
+++ b/test/additional-tests.txt
@@ -1,2 +1,3 @@
 http://127.0.0.1:10100/relative_import.html  s:http h:127.0.0.1 port:10100 p:/relative_import.html
 http://facebook.com/?foo=%7B%22abc%22  s:http h:facebook.com p:/ q:?foo=%7B%22abc%22
+https://localhost:3000/jqueryui@1.2.3 s:https h:localhost port:3000 p:/jqueryui@1.2.3

--- a/test/additional-tests.txt
+++ b/test/additional-tests.txt
@@ -1,3 +1,3 @@
 http://127.0.0.1:10100/relative_import.html  s:http h:127.0.0.1 port:10100 p:/relative_import.html
 http://facebook.com/?foo=%7B%22abc%22  s:http h:facebook.com p:/ q:?foo=%7B%22abc%22
-https://localhost:3000/jqueryui@1.2.3 s:https h:localhost port:3000 p:/jqueryui@1.2.3
+https://localhost:3000/jqueryui@1.2.3  s:https h:localhost port:3000 p:/jqueryui@1.2.3


### PR DESCRIPTION
As I understand the spec (my understanding can be incorrect), the path should support @.  

I am referencing the 3rd step in the path state:  
https://url.spec.whatwg.org/#path-state which should support the URL Code Points.  https://url.spec.whatwg.org/#url-code-points

I tried adding a fix but my url parsing & state machine 'foos' are very weak. =)  

