### PR TITLE
Make %2E as well as %2e be turned into .

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ whatwg-url is a full implementation of the WHATWG [URL Standard](https://url.spe
 
 ## Current Status
 
-whatwg-url is currently up to date with the URL spec up to commit [af76ff](https://github.com/whatwg/url/commit/af76ff3aa15be6310b9408d416854c2370175a8f).
+whatwg-url is currently up to date with the URL spec up to commit [a9197f](a9197f7714e6b125f1f760ca1aa661530261773c).
 
 ## API
 

--- a/scripts/get-latest-platform-tests.js
+++ b/scripts/get-latest-platform-tests.js
@@ -15,7 +15,7 @@ const request = require("request");
 // 1. Go to https://github.com/w3c/web-platform-tests/blob/master/url/urltestdata.json
 // 2. Press "y" on your keyboard to get a permalink
 // 3. Copy the commit hash
-const commitHash = "47d2089cb11d5f5047f3bd2f183eecd471bc2d07";
+const commitHash = "77267eb15cbce849ac01c95fc4d85015a28539e5";
 
 const sourceURL = `https://raw.githubusercontent.com/w3c/web-platform-tests/${commitHash}/url/urltestdata.json`;
 

--- a/src/url-state-machine.js
+++ b/src/url-state-machine.js
@@ -952,7 +952,7 @@ URLStateMachine.prototype["parse" + "path"] =
 
     if (c === p("%") &&
         this.input[this.pointer + 1] === p("2") &&
-        this.input[this.pointer + 2] === p("e")) {
+        (this.input[this.pointer + 2] === p("e") || this.input[this.pointer + 2] === p("E"))) {
       this.buffer += ".";
       this.pointer += 2;
     } else {


### PR DESCRIPTION
It turns out d1dc30674f208a8c2ab54ac1c4dd91848d4b1078 was incomplete and didn't account for the spec's lowercase comparison. Raised by https://github.com/w3c/web-platform-tests/pull/2569.