### PR TITLE
[do not merge] Ensure pop path does not pop for file URLs

### DIFF
--- a/src/url-state-machine.js
+++ b/src/url-state-machine.js
@@ -911,7 +911,11 @@ URLStateMachine.prototype["parse path"] = function parsePath(c) {
     }
 
     if (isDoubleDot(this.buffer)) {
-      this.url.path.pop();
+      if (this.url.scheme === "file") {
+        this.url.path.push(this.buffer);
+      } else {
+        this.url.path.pop();
+      }
       if (c !== p("/") && !(specialSchemas[this.url.scheme] !== undefined && c === p("\\"))) {
         this.url.path.push("");
       }


### PR DESCRIPTION
this PR fixes a special case for pop path when the URL is a file URL: https://url.spec.whatwg.org/#pop-a-urls-path

this makes a test fail, but I am unsure where the tests came from:

```
 1) Web platform tests parsing <file:..> against <http://www.example.com/test>:

      AssertionError: href
      + expected - actual

      -file:///../
      +file:///
```
