### PR TITLE
Spec update: get rid of null passwords

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ whatwg-url is a full implementation of the WHATWG [URL Standard](https://url.spe
 
 ## Current Status
 
-whatwg-url is currently up to date with the URL spec up to commit [373dbe](https://github.com/whatwg/url/tree/373dbedbbf0596f723ce8a195923da98b698aeb0).
+whatwg-url is currently up to date with the URL spec up to commit [5e0b05](https://github.com/whatwg/url/tree/5e0b05e95a81fdd539c7b1bf97e69b3df701384f).
 
 ## API
 

--- a/lib/URL-impl.js
+++ b/lib/URL-impl.js
@@ -62,10 +62,6 @@ exports.implementation = class URLImpl {
   }
 
   get password() {
-    if (this._url.password === null) {
-      return "";
-    }
-
     return this._url.password;
   }
 

--- a/scripts/get-latest-platform-tests.js
+++ b/scripts/get-latest-platform-tests.js
@@ -15,7 +15,7 @@ const request = require("request");
 // 1. Go to https://github.com/w3c/web-platform-tests/tree/master/url
 // 2. Press "y" on your keyboard to get a permalink
 // 3. Copy the commit hash
-const commitHash = "f89847d4df8bb732a51c0669b3d4fa6718c71e54";
+const commitHash = "e0012406859014e8f31dbaf12122d0cd10249db4";
 
 const sourceURL = `https://raw.githubusercontent.com/w3c/web-platform-tests/${commitHash}/url/urltestdata.json`;
 const setterSourceURL = `https://raw.githubusercontent.com/w3c/web-platform-tests/${commitHash}/url/setters_tests.json`;

--- a/scripts/get-latest-platform-tests.js
+++ b/scripts/get-latest-platform-tests.js
@@ -15,7 +15,7 @@ const request = require("request");
 // 1. Go to https://github.com/w3c/web-platform-tests/tree/master/url
 // 2. Press "y" on your keyboard to get a permalink
 // 3. Copy the commit hash
-const commitHash = "5be497b5f5a7036e26dc14739aa8d42f643cf94f";
+const commitHash = "f89847d4df8bb732a51c0669b3d4fa6718c71e54";
 
 const sourceURL = `https://raw.githubusercontent.com/w3c/web-platform-tests/${commitHash}/url/urltestdata.json`;
 const setterSourceURL = `https://raw.githubusercontent.com/w3c/web-platform-tests/${commitHash}/url/setters_tests.json`;

--- a/src/url-state-machine.js
+++ b/src/url-state-machine.js
@@ -486,6 +486,7 @@ function URLStateMachine(input, base, encodingOverride, url, stateOverride) {
   this.buffer = "";
   this.atFlag = false;
   this.arrFlag = false;
+  this.passwordTokenSeenFlag = false;
 
   this.input = punycode.ucs2.decode(this.input);
 
@@ -707,19 +708,17 @@ URLStateMachine.prototype["parse authority"] = function parseAuthority(c, cStr) 
     }
     this.atFlag = true;
 
-    let passwordTokenSeenFlag = false;
-
     // careful, this is based on buffer and has its own pointer (this.pointer != pointer) and inner chars
     const len = countSymbols(this.buffer);
     for (let pointer = 0; pointer < len; ++pointer) {
       const codePoint = this.buffer.codePointAt(pointer);
 
-      if (codePoint === p(":") && !passwordTokenSeenFlag) {
-        passwordTokenSeenFlag = true;
+      if (codePoint === p(":") && !this.passwordTokenSeenFlag) {
+        this.passwordTokenSeenFlag = true;
         continue;
       }
       const encodedCodePoints = encodeChar(codePoint, isUserInfoEncode);
-      if (passwordTokenSeenFlag) {
+      if (this.passwordTokenSeenFlag) {
         this.url.password += encodedCodePoints;
       } else {
         this.url.username += encodedCodePoints;


### PR DESCRIPTION
This aligns with https://github.com/whatwg/url/pull/186.

/cc @annevk. As mentioned in https://github.com/w3c/web-platform-tests/pull/4405#issuecomment-269654674 one test is failing with this change, so something's not right---either in the tests, in the translation of the spec PR into code, or in the spec.

We should not merge this until the WPT PR is merged, and then we should update the commit hash to point to WPT master.