### PR TITLE
Spec update: treat URLs without a special scheme differently

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ The following methods are exported for use by places like jsdom that need to imp
 - [Serialize an integer](https://url.spec.whatwg.org/#serialize-an-integer): `serializeInteger(number)`
 - [Origin](https://url.spec.whatwg.org/#concept-url-origin) [Unicode serializer](https://html.spec.whatwg.org/multipage/browsers.html#unicode-serialisation-of-an-origin): `serializeURLToUnicodeOrigin(urlRecord)`
 - [Set the username](https://url.spec.whatwg.org/#set-the-username): `setTheUsername(urlRecord, usernameString)`
-- [Set the password](https://url.spec.whatwg.org/#set-the-password): `setThePassword(urlRecord, passwordString)`.
+- [Set the password](https://url.spec.whatwg.org/#set-the-password): `setThePassword(urlRecord, passwordString)`
+- [Is special](https://url.spec.whatwg.org/#is-special): `isSpecial(urlRecord)`
 
 The `stateOverride` parameter is one of the following strings:
 

--- a/lib/URL-impl.js
+++ b/lib/URL-impl.js
@@ -140,6 +140,10 @@ exports.implementation = class URLImpl {
       return this._url.path[0];
     }
 
+    if (!usm.isSpecial(this._url) && this._url.path.length === 0) {
+      return "";
+    }
+
     return "/" + this._url.path.join("/");
   }
 

--- a/scripts/get-latest-platform-tests.js
+++ b/scripts/get-latest-platform-tests.js
@@ -15,7 +15,7 @@ const request = require("request");
 // 1. Go to https://github.com/w3c/web-platform-tests/tree/master/url
 // 2. Press "y" on your keyboard to get a permalink
 // 3. Copy the commit hash
-const commitHash = "5be497b5f5a7036e26dc14739aa8d42f643cf94f";
+const commitHash = "2c87b7d14b07b9383b837278e475d202969f6b64";
 
 const sourceURL = `https://raw.githubusercontent.com/w3c/web-platform-tests/${commitHash}/url/urltestdata.json`;
 const setterSourceURL = `https://raw.githubusercontent.com/w3c/web-platform-tests/${commitHash}/url/setters_tests.json`;


### PR DESCRIPTION
This matches https://github.com/whatwg/url/pull/185.

This one also runs into several failing tests from the new WPT set. I suspect they are spec bugs, but they could be test bugs or spec-translation-into-JS bugs. They are:

```
1) Web platform tests parsing <sc://ñ> against <about:blank>:

      AssertionError: href
      + expected - actual

      -sc://%C3%B1/
      +sc://%C3%B1
```

```
 2) Web platform tests setters host <view-source+http://example.net/path>.host = "example.com\stuff" \ is not a delimiter for non-special schemes, and it’s invalid in a domain:

      AssertionError: 'view-source+http://example.com\\stuff/path' == 'view-source+http://example.net/path'
      + expected - actual

      -view-source+http://example.com\stuff/path
      +view-source+http://example.net/path
```

```
  3) Web platform tests setters hostname <view-source+http://example.net/path>.hostname = "example.com\stuff" \ is not a delimiter for non-special schemes, and it’s invalid in a domain:

      AssertionError: 'view-source+http://example.com\\stuff/path' == 'view-source+http://example.net/path'
      + expected - actual

      -view-source+http://example.com\stuff/path
      +view-source+http://example.net/path
```

/cc @annevk

We should not merge this until the WPT PRs make it into master