### PR TITLE
Spec update: stop decoding all %2es in paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ whatwg-url is a full implementation of the WHATWG [URL Standard](https://url.spe
 
 ## Current Status
 
-whatwg-url is currently up to date with the URL spec up to commit [5e0b05](https://github.com/whatwg/url/tree/5e0b05e95a81fdd539c7b1bf97e69b3df701384f).
+whatwg-url is currently up to date with the URL spec up to commit [fbff68](https://github.com/whatwg/url/tree/fbff6834a8a03576261f777d0e0afea5c1bc5a09).
 
 ## API
 

--- a/scripts/get-latest-platform-tests.js
+++ b/scripts/get-latest-platform-tests.js
@@ -15,11 +15,7 @@ const request = require("request");
 // 1. Go to https://github.com/w3c/web-platform-tests/tree/master/url
 // 2. Press "y" on your keyboard to get a permalink
 // 3. Copy the commit hash
-<<<<<<< HEAD
-const commitHash = "e0012406859014e8f31dbaf12122d0cd10249db4";
-=======
-const commitHash = "d179f7eadbe83a6fa9bf7ee85c2de440b8c6dc7d";
->>>>>>> Spec update: stop decoding all %2es in paths
+const commitHash = "d93247d5cb7d70f80da8b154a171f4e3d50969f4";
 
 const sourceURL = `https://raw.githubusercontent.com/w3c/web-platform-tests/${commitHash}/url/urltestdata.json`;
 const setterSourceURL = `https://raw.githubusercontent.com/w3c/web-platform-tests/${commitHash}/url/setters_tests.json`;

--- a/scripts/get-latest-platform-tests.js
+++ b/scripts/get-latest-platform-tests.js
@@ -15,7 +15,11 @@ const request = require("request");
 // 1. Go to https://github.com/w3c/web-platform-tests/tree/master/url
 // 2. Press "y" on your keyboard to get a permalink
 // 3. Copy the commit hash
+<<<<<<< HEAD
 const commitHash = "e0012406859014e8f31dbaf12122d0cd10249db4";
+=======
+const commitHash = "d179f7eadbe83a6fa9bf7ee85c2de440b8c6dc7d";
+>>>>>>> Spec update: stop decoding all %2es in paths
 
 const sourceURL = `https://raw.githubusercontent.com/w3c/web-platform-tests/${commitHash}/url/urltestdata.json`;
 const setterSourceURL = `https://raw.githubusercontent.com/w3c/web-platform-tests/${commitHash}/url/setters_tests.json`;

--- a/src/url-state-machine.js
+++ b/src/url-state-machine.js
@@ -976,14 +976,7 @@ URLStateMachine.prototype["parse path"] = function parsePath(c) {
       this.parseError = true;
     }
 
-    if (c === p("%") &&
-        this.input[this.pointer + 1] === p("2") &&
-        (this.input[this.pointer + 2] === p("e") || this.input[this.pointer + 2] === p("E"))) {
-      this.buffer += ".";
-      this.pointer += 2;
-    } else {
-      this.buffer += encodeChar(c, isDefaultEncode);
-    }
+    this.buffer += encodeChar(c, isDefaultEncode);
   }
 
   return true;


### PR DESCRIPTION
This follows https://github.com/whatwg/url/pull/156.

/cc @annevk. As noted in https://github.com/w3c/web-platform-tests/pull/4104#issuecomment-269660695 there are still some tests that need to be updated for this spec change I believe.