### PR TITLE
Spec update: disallow invalid IPv4 in the IPv6 parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ whatwg-url is a full implementation of the WHATWG [URL Standard](https://url.spe
 
 ## Current Status
 
-whatwg-url is currently up to date with the URL spec up to commit [fbff68](https://github.com/whatwg/url/tree/fbff6834a8a03576261f777d0e0afea5c1bc5a09).
+whatwg-url is currently up to date with the URL spec up to commit [a7ae1b](https://github.com/whatwg/url/tree/a7ae1b846b91d564229faeaafdd28cb7451faa1d).
 
 ## API
 

--- a/scripts/get-latest-platform-tests.js
+++ b/scripts/get-latest-platform-tests.js
@@ -9,13 +9,12 @@ const fs = require("fs");
 const request = require("request");
 
 // Pin to specific version, reflecting the spec version in the readme.
-// At the moment we are pinned to a branch.
 //
 // To get the latest commit:
 // 1. Go to https://github.com/w3c/web-platform-tests/tree/master/url
 // 2. Press "y" on your keyboard to get a permalink
 // 3. Copy the commit hash
-const commitHash = "6e9508aab07d0c3e81e2ae60bac32290c02cd8f2";
+const commitHash = "82173128ef6f536e5faaafc29eecc521380f81ae";
 
 const sourceURL = `https://raw.githubusercontent.com/w3c/web-platform-tests/${commitHash}/url/urltestdata.json`;
 const setterSourceURL = `https://raw.githubusercontent.com/w3c/web-platform-tests/${commitHash}/url/setters_tests.json`;

--- a/scripts/get-latest-platform-tests.js
+++ b/scripts/get-latest-platform-tests.js
@@ -15,7 +15,7 @@ const request = require("request");
 // 1. Go to https://github.com/w3c/web-platform-tests/tree/master/url
 // 2. Press "y" on your keyboard to get a permalink
 // 3. Copy the commit hash
-const commitHash = "1e1e80441b8d6a60f836de4005dba25698ecfe4a";
+const commitHash = "6e9508aab07d0c3e81e2ae60bac32290c02cd8f2";
 
 const sourceURL = `https://raw.githubusercontent.com/w3c/web-platform-tests/${commitHash}/url/urltestdata.json`;
 const setterSourceURL = `https://raw.githubusercontent.com/w3c/web-platform-tests/${commitHash}/url/setters_tests.json`;

--- a/src/url-state-machine.js
+++ b/src/url-state-machine.js
@@ -301,22 +301,24 @@ function parseIPv6(input) {
         }
       }
 
-      if (dotsSeen < 3 && input[pointer] !== p(".")) {
-        return failure;
-      }
       ip[piecePtr] = ip[piecePtr] * 0x100 + value;
+
       if (dotsSeen === 1 || dotsSeen === 3) {
         ++piecePtr;
       }
 
-      if (input[pointer] !== undefined) {
-        ++pointer;
-      }
-
-      if (dotsSeen === 3 && input[pointer] !== undefined) {
+      if (input[pointer] === undefined && dotsSeen !== 3) {
         return failure;
       }
-      ++dotsSeen;
+
+      if (input[pointer] === p(".")) {
+        ++pointer;
+        ++dotsSeen;
+
+        if (input[pointer] === undefined) {
+          return failure;
+        }
+      }
     }
   }
 

--- a/src/url-state-machine.js
+++ b/src/url-state-machine.js
@@ -278,10 +278,19 @@ function parseIPv6(input) {
   if (ipv4 && piecePtr > 6) {
     return failure;
   } else if (input[pointer] !== undefined) {
-    let dotsSeen = 0;
+    let numbersSeen = 0;
 
     while (input[pointer] !== undefined) {
       let value = null;
+
+      if (numbersSeen > 0) {
+        if (input[pointer] === p(".") && numbersSeen < 4) {
+          ++pointer;
+        } else {
+          return failure;
+        }
+      }
+
       if (!isASCIIDigit(input[pointer])) {
         return failure;
       }
@@ -303,21 +312,14 @@ function parseIPv6(input) {
 
       ip[piecePtr] = ip[piecePtr] * 0x100 + value;
 
-      if (dotsSeen === 1 || dotsSeen === 3) {
+      ++numbersSeen;
+
+      if (numbersSeen === 2 || numbersSeen === 4) {
         ++piecePtr;
       }
 
-      if (input[pointer] === undefined && dotsSeen !== 3) {
+      if (input[pointer] === undefined && numbersSeen !== 4) {
         return failure;
-      }
-
-      if (input[pointer] === p(".")) {
-        ++pointer;
-        ++dotsSeen;
-
-        if (input[pointer] === undefined) {
-          return failure;
-        }
       }
     }
   }


### PR DESCRIPTION
This matches https://github.com/whatwg/url/pull/196.

---

We shouldn't merge until the WPTs make it into master.