### PR TITLE
Fix: not compressing trailing zeros in IPv6

### DIFF
--- a/src/url-state-machine.js
+++ b/src/url-state-machine.js
@@ -413,6 +413,12 @@ function findLongestZeroSequence(arr) {
     }
   }
 
+  // if trailing zeros
+  if (currLen > maxLen) {
+    maxIdx = currStart;
+    maxLen = currLen;
+  }
+
   return {
     idx: maxIdx,
     len: maxLen

--- a/test/to-upstream.json
+++ b/test/to-upstream.json
@@ -1,2 +1,18 @@
 [
+  "# IPv6 trailing zeros compress test",
+  {
+    "input": "http://[1:0::]",
+    "base": "http://example.net/",
+    "href": "http://[1::]/",
+    "origin": "http://[1::]",
+    "protocol": "http:",
+    "username": "",
+    "password": "",
+    "host": "[1::]",
+    "hostname": "[1::]",
+    "port": "",
+    "pathname": "/",
+    "search": "",
+    "hash": ""
+  }
 ]


### PR DESCRIPTION
Fixed bug in function `findLongestZeroSequence`, which has ignored trailing zeros sequences.

URL to test isssue:
`http://[1:0::]`

`url.host` in original version returns `[1:0:0:0:0:0:0:0]`, but must return: `[1::]`