### PR TITLE
Parsing of "http://../" is not correct

### DIFF
--- a/src/url-state-machine.js
+++ b/src/url-state-machine.js
@@ -183,6 +183,10 @@ function parseIPv4(input) {
 
   const numbers = [];
   for (const part of parts) {
+    if (part === "") {
+      return input;
+    }
+
     const n = parseIPv4Number(part);
     if (n === failure) {
       return input;


### PR DESCRIPTION
`http://../` is parsed to `http://0.0.0.0/`

But must be parsed to `http://../`

It looks like IPv4 parser treats empty parts as 0, but https://url.spec.whatwg.org/#concept-ipv4-parser 6.1 says:

> 1. If part is the empty string, return input.
