### PR TITLE
Spec update: IPv4 in IPv6 cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ whatwg-url is a full implementation of the WHATWG [URL Standard](https://url.spe
 
 ## Current Status
 
-whatwg-url is currently up to date with the URL spec up to commit [703fcd](https://github.com/whatwg/url/commit/703fcd0b92053345582a36b2e4a642ab65df076e).
+whatwg-url is currently up to date with the URL spec up to commit [488c45](https://github.com/whatwg/url/commit/488c459d9e4245a3f6bf087e7dcd2c7e91487ac5).
 
 ## API
 

--- a/src/url-state-machine.js
+++ b/src/url-state-machine.js
@@ -305,10 +305,10 @@ function parseIPv6(input) {
           } else {
             ipv4Piece = ipv4Piece * 10 + number;
           }
-          ++pointer;
           if (ipv4Piece > 255) {
             return failure;
           }
+          ++pointer;
         }
 
         ip[piecePtr] = ip[piecePtr] * 0x100 + ipv4Piece;
@@ -318,10 +318,10 @@ function parseIPv6(input) {
         if (numbersSeen === 2 || numbersSeen === 4) {
           ++piecePtr;
         }
+      }
 
-        if (input[pointer] === undefined && numbersSeen !== 4) {
-          return failure;
-        }
+      if (numbersSeen !== 4) {
+        return failure;
       }
 
       break;


### PR DESCRIPTION
Follows https://github.com/whatwg/url/pull/292.