### PR TITLE
Serialize origins as ASCII instead of Unicode

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The following methods are exported for use by places like jsdom that need to imp
 - [URL serializer](https://url.spec.whatwg.org/#concept-url-serializer): `serializeURL(urlRecord, excludeFragment)`
 - [Host serializer](https://url.spec.whatwg.org/#concept-host-serializer): `serializeHost(hostFromURLRecord)`
 - [Serialize an integer](https://url.spec.whatwg.org/#serialize-an-integer): `serializeInteger(number)`
-- [Origin](https://url.spec.whatwg.org/#concept-url-origin) [Unicode serializer](https://html.spec.whatwg.org/multipage/browsers.html#unicode-serialisation-of-an-origin): `serializeURLToUnicodeOrigin(urlRecord)`
+- [Origin](https://url.spec.whatwg.org/#concept-url-origin) [serializer](https://html.spec.whatwg.org/multipage/browsers.html#serialization-of-an-origin): `serializeURLOrigin(urlRecord)`
 - [Set the username](https://url.spec.whatwg.org/#set-the-username): `setTheUsername(urlRecord, usernameString)`
 - [Set the password](https://url.spec.whatwg.org/#set-the-password): `setThePassword(urlRecord, passwordString)`
 - [Cannot have a username/password/port](https://url.spec.whatwg.org/#cannot-have-a-username-password-port): `cannotHaveAUsernamePasswordPort(urlRecord)`

--- a/lib/URL-impl.js
+++ b/lib/URL-impl.js
@@ -38,7 +38,7 @@ exports.implementation = class URLImpl {
   }
 
   get origin() {
-    return usm.serializeURLToUnicodeOrigin(this._url);
+    return usm.serializeURLOrigin(this._url);
   }
 
   get protocol() {

--- a/lib/public-api.js
+++ b/lib/public-api.js
@@ -2,7 +2,7 @@
 
 exports.URL = require("./URL").interface;
 exports.serializeURL = require("./url-state-machine").serializeURL;
-exports.serializeURLToUnicodeOrigin = require("./url-state-machine").serializeURLToUnicodeOrigin;
+exports.serializeURLOrigin = require("./url-state-machine").serializeURLOrigin;
 exports.basicURLParse = require("./url-state-machine").basicURLParse;
 exports.setTheUsername = require("./url-state-machine").setTheUsername;
 exports.setThePassword = require("./url-state-machine").setThePassword;

--- a/scripts/get-latest-platform-tests.js
+++ b/scripts/get-latest-platform-tests.js
@@ -14,7 +14,7 @@ const request = require("request");
 // 1. Go to https://github.com/w3c/web-platform-tests/tree/master/url
 // 2. Press "y" on your keyboard to get a permalink
 // 3. Copy the commit hash
-const commitHash = "5ae94e10d50e76fdfc120863c198d3a3937000dc";
+const commitHash = "34435a45164168db1403842ea7210bc99c4ef35b";
 
 const sourceURL = `https://raw.githubusercontent.com/w3c/web-platform-tests/${commitHash}/url/urltestdata.json`;
 const setterSourceURL = `https://raw.githubusercontent.com/w3c/web-platform-tests/${commitHash}/url/setters_tests.json`;

--- a/src/url-state-machine.js
+++ b/src/url-state-machine.js
@@ -1212,12 +1212,8 @@ function serializeURL(url, excludeFragment) {
 }
 
 function serializeOrigin(tuple) {
-  if (tuple.scheme === undefined || tuple.host === undefined || tuple.port === undefined) {
-    return "null";
-  }
-
   let result = tuple.scheme + "://";
-  result += tr46.toUnicode(tuple.host, false).domain;
+  result += serializeHost(tuple.host);
 
   if (tuple.port !== null) {
     result += ":" + tuple.port;
@@ -1228,13 +1224,14 @@ function serializeOrigin(tuple) {
 
 module.exports.serializeURL = serializeURL;
 
-module.exports.serializeURLToUnicodeOrigin = function (url) {
+module.exports.serializeURLOrigin = function (url) {
+  // https://url.spec.whatwg.org/#concept-url-origin
   switch (url.scheme) {
     case "blob":
       try {
-        return module.exports.serializeURLToUnicodeOrigin(module.exports.parseURL(url.path[0]));
+        return module.exports.serializeURLOrigin(module.exports.parseURL(url.path[0]));
       } catch (e) {
-        // serializing an opaque identifier returns "null"
+        // serializing an opaque origin returns "null"
         return "null";
       }
     case "ftp":
@@ -1245,14 +1242,14 @@ module.exports.serializeURLToUnicodeOrigin = function (url) {
     case "wss":
       return serializeOrigin({
         scheme: url.scheme,
-        host: serializeHost(url.host),
+        host: url.host,
         port: url.port
       });
     case "file":
       // spec says "exercise to the reader", chrome says "file://"
       return "file://";
     default:
-      // serializing an opaque identifier returns "null"
+      // serializing an opaque origin returns "null"
       return "null";
   }
 };


### PR DESCRIPTION
Follows https://github.com/whatwg/url/pull/311. This is both a spec update and a public API change.