### PR TITLE
Expose utf8PercentEncode/Decode

### DIFF
--- a/lib/public-api.js
+++ b/lib/public-api.js
@@ -9,3 +9,5 @@ exports.setThePassword = require("./url-state-machine").setThePassword;
 exports.serializeHost = require("./url-state-machine").serializeHost;
 exports.serializeInteger = require("./url-state-machine").serializeInteger;
 exports.parseURL = require("./url-state-machine").parseURL;
+exports.utf8PercentEncode = require("./url-state-machine").utf8PercentEncode;
+exports.utf8PercentDecode = require("./url-state-machine").utf8PercentDecode;

--- a/src/url-state-machine.js
+++ b/src/url-state-machine.js
@@ -93,7 +93,8 @@ function percentEncode(c) {
   return "%" + hex;
 }
 
-function utf8PercentEncode(c) {
+// https://url.spec.whatwg.org/#percent-encode
+module.exports = function utf8PercentEncode(c) {
   const buf = new Buffer(c);
 
   let str = "";
@@ -105,7 +106,8 @@ function utf8PercentEncode(c) {
   return str;
 }
 
-function utf8PercentDecode(str) {
+// https://url.spec.whatwg.org/#percent-decode
+module.exports = function utf8PercentDecode(str) {
   const input = new Buffer(str);
   const output = [];
   for (let i = 0; i < input.length; ++i) {

--- a/src/url-state-machine.js
+++ b/src/url-state-machine.js
@@ -94,7 +94,7 @@ function percentEncode(c) {
 }
 
 // https://url.spec.whatwg.org/#percent-encode
-module.exports = function utf8PercentEncode(c) {
+function utf8PercentEncode(c) {
   const buf = new Buffer(c);
 
   let str = "";
@@ -105,9 +105,10 @@ module.exports = function utf8PercentEncode(c) {
 
   return str;
 }
+module.exports.utf8PercentEncode = utf8PercentEncode;
 
 // https://url.spec.whatwg.org/#percent-decode
-module.exports = function utf8PercentDecode(str) {
+function utf8PercentDecode(str) {
   const input = new Buffer(str);
   const output = [];
   for (let i = 0; i < input.length; ++i) {
@@ -122,6 +123,7 @@ module.exports = function utf8PercentDecode(str) {
   }
   return new Buffer(output).toString();
 }
+module.exports.utf8PercentDecode = utf8PercentDecode;
 
 function isC0ControlPercentEncode(c) {
   return c <= 0x1F || c > 0x7E;


### PR DESCRIPTION
As discussed in https://github.com/tmpvar/jsdom/pull/1902 these functions are used more widely than just for urls, so it would be useful to expose them.