### PR TITLE
Update tests for new way of testing bad base URLs

### DIFF
--- a/scripts/get-latest-platform-tests.js
+++ b/scripts/get-latest-platform-tests.js
@@ -19,7 +19,7 @@ process.on("unhandledRejection", err => {
 // 1. Go to https://github.com/w3c/web-platform-tests/tree/master/url
 // 2. Press "y" on your keyboard to get a permalink
 // 3. Copy the commit hash
-const commitHash = "0050cfbe145bc9c24981186fa47e714147c1674d";
+const commitHash = "88b75886e68ce5197019a2707fc6f1b9645a4639";
 
 // Have to use RawGit as JSDOM.fromURL checks Content-Type header.
 const urlPrefix = `https://rawgit.com/w3c/web-platform-tests/${commitHash}/url/`;

--- a/test/web-platform.js
+++ b/test/web-platform.js
@@ -150,6 +150,22 @@ describe("Web platform tests", () => {
     }
   });
 
+  describe("bad base URL", () => {
+    for (const rawExpected of parsingTestCases) {
+      if (typeof rawExpected === "string" || !rawExpected.failure) {
+        continue;
+      }
+
+      const expected = {
+        input: "about:blank",
+        base: rawExpected.input,
+        failure: true
+      };
+
+      test(`<${expected.input}> against <${expected.base}>`, testURL(expected));
+    }
+  });
+
   describe("setters", () => {
     for (const key of Object.keys(setterTestData)) {
       if (key === "comment") {


### PR DESCRIPTION
Follows https://github.com/w3c/web-platform-tests/pull/10955.

(Waiting on that PR to be merged, then update the commit hash, before merging this. This PR is mostly being put up as an example to the Node.js folks what they can do.)