### PR TITLE
Change file: URLs to have an opaque origin

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 
 whatwg-url is a full implementation of the WHATWG [URL Standard](https://url.spec.whatwg.org/). It can be used standalone, but it also exposes a lot of the internal algorithms that are useful for integrating a URL parser into a project like [jsdom](https://github.com/tmpvar/jsdom).
 
-## Current status
+## Specification conformance
 
 whatwg-url is currently up to date with the URL spec up to commit [6ef17eb](https://github.com/whatwg/url/commit/6ef17ebe1220a7e7c0cfff0785017502ee18808b).
+
+For `file:` URLs, whose [origin is left unspecified](https://url.spec.whatwg.org/#concept-url-origin), whatwg-url chooses to use a new opaque origin (which serializes to `"null"`).
 
 ## API
 

--- a/src/url-state-machine.js
+++ b/src/url-state-machine.js
@@ -1248,8 +1248,14 @@ module.exports.serializeURLOrigin = function (url) {
         port: url.port
       });
     case "file":
-      // spec says "exercise to the reader", chrome says "file://"
-      return "file://";
+      // The spec says:
+      // > Unfortunate as it is, this is left as an exercise to the reader. When in doubt, return a new opaque origin.
+      // Browsers tested so far:
+      // - Chrome says "file://", but treats file: URLs as cross-origin for most (all?) purposes; see e.g.
+      //   https://bugs.chromium.org/p/chromium/issues/detail?id=37586
+      // - Firefox says "null", but treats file: URLs as same-origin sometimes based on directory stuff; see
+      //   https://developer.mozilla.org/en-US/docs/Archive/Misc_top_level/Same-origin_policy_for_file:_URIs
+      return "null";
     default:
       // serializing an opaque origin returns "null"
       return "null";

--- a/test/file-url-origin.js
+++ b/test/file-url-origin.js
@@ -1,0 +1,14 @@
+"use strict";
+const assert = require("assert");
+const { URL, parseURL, serializeURLOrigin } = require("..");
+
+test("new URL gives a null origin for file URLs", () => {
+  const url = new URL("file:///C:/demo");
+  assert.strictEqual(url.origin, "null");
+});
+
+test("serializeURLOrigin gives a null origin for file URLs", () => {
+  const urlRecord = parseURL("file:///C:/demo");
+  const origin = serializeURLOrigin(urlRecord);
+  assert.strictEqual(origin, "null");
+});


### PR DESCRIPTION
Closes #117.

I think for the purposes of our consumers this should be considered a breaking change.