### PR TITLE
Update to the central lodash package

### DIFF
--- a/lib/URLSearchParams-impl.js
+++ b/lib/URLSearchParams-impl.js
@@ -1,5 +1,5 @@
 "use strict";
-const stableSortBy = require("lodash.sortby");
+const stableSortBy = require("lodash").sortBy;
 const urlencoded = require("./urlencoded");
 
 exports.implementation = class URLSearchParamsImpl {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "repository": "jsdom/whatwg-url",
   "dependencies": {
-    "lodash.sortby": "^4.7.0",
+    "lodash": "^4.17.11",
     "tr46": "^1.0.1",
     "webidl-conversions": "^4.0.2"
   },


### PR DESCRIPTION
Update the reference to use the central lodash package instead of the single-function package. Will allow keeping up to date with new lodash versions as they reduce support for the single-function packages.

Fixes #127 