### PR TITLE
chore, remove lodash.sortby with lodash/sortBy

### DIFF
--- a/lib/URLSearchParams-impl.js
+++ b/lib/URLSearchParams-impl.js
@@ -1,5 +1,5 @@
 "use strict";
-const stableSortBy = require("lodash.sortby");
+const stableSortBy = require("lodash/sortBy");
 const urlencoded = require("./urlencoded");
 
 exports.implementation = class URLSearchParamsImpl {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "repository": "jsdom/whatwg-url",
   "dependencies": {
-    "lodash.sortby": "^4.7.0",
+    "lodash": "^4.17.11",
     "tr46": "^1.0.1",
     "webidl-conversions": "^4.0.2"
   },


### PR DESCRIPTION
User is going to have lodash installed anyway. This would reduce the app size and might have a higher chance of using require cache. lodash.sortby is not small module by itself. 