### PR TITLE
Spec update: verify domain is not empty after Unicode ToASCII

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ whatwg-url is a full implementation of the WHATWG [URL Standard](https://url.spe
 
 ## Specification conformance
 
-whatwg-url is currently up to date with the URL spec up to commit [7ae1c69](https://github.com/whatwg/url/commit/7ae1c691c96f0d82fafa24c33aa1e8df9ffbf2bc).
+whatwg-url is currently up to date with the URL spec up to commit [cceb435](https://github.com/whatwg/url/commit/cceb4356cca233b6dfdaabd888263157b2204e44).
 
 For `file:` URLs, whose [origin is left unspecified](https://url.spec.whatwg.org/#concept-url-origin), whatwg-url chooses to use a new opaque origin (which serializes to `"null"`).
 

--- a/scripts/get-latest-platform-tests.js
+++ b/scripts/get-latest-platform-tests.js
@@ -23,7 +23,7 @@ process.on("unhandledRejection", err => {
 // 1. Go to https://github.com/w3c/web-platform-tests/tree/master/url
 // 2. Press "y" on your keyboard to get a permalink
 // 3. Copy the commit hash
-const commitHash = "59e50d35ef02a8992dce8980784c14010ebf7c98";
+const commitHash = "c390f441840c65b55f014a34ef0459853709286b";
 
 const urlPrefix = `https://raw.githubusercontent.com/web-platform-tests/wpt/${commitHash}/url/`;
 const targetDir = path.resolve(__dirname, "..", "test", "web-platform-tests");

--- a/src/url-state-machine.js
+++ b/src/url-state-machine.js
@@ -465,7 +465,7 @@ function domainToASCII(domain, beStrict = false) {
     useSTD3ASCIIRules: beStrict,
     verifyDNSLength: beStrict
   });
-  if (result === null) {
+  if (result === null || result === "") {
     return failure;
   }
   return result;


### PR DESCRIPTION
Follows https://github.com/whatwg/url/commit/cceb4356cca233b6dfdaabd888263157b2204e44.