### PR TITLE
Spec update: make everything use percent-encode sets

### DIFF
--- a/src/URL-impl.js
+++ b/src/URL-impl.js
@@ -46,7 +46,7 @@ exports.implementation = class URLImpl {
     this._query._list.splice(0);
     const { query } = parsedURL;
     if (query !== null) {
-      this._query._list = urlencoded.parseUrlencoded(query);
+      this._query._list = urlencoded.parseUrlencodedString(query);
     }
   }
 
@@ -185,7 +185,7 @@ exports.implementation = class URLImpl {
     const input = v[0] === "?" ? v.substring(1) : v;
     url.query = "";
     usm.basicURLParse(input, { url, stateOverride: "query" });
-    this._query._list = urlencoded.parseUrlencoded(input);
+    this._query._list = urlencoded.parseUrlencodedString(input);
   }
 
   get searchParams() {

--- a/src/URLSearchParams-impl.js
+++ b/src/URLSearchParams-impl.js
@@ -26,7 +26,7 @@ exports.implementation = class URLSearchParamsImpl {
         this._list.push([name, value]);
       }
     } else {
-      this._list = urlencoded.parseUrlencoded(init);
+      this._list = urlencoded.parseUrlencodedString(init);
     }
   }
 

--- a/src/encoding.js
+++ b/src/encoding.js
@@ -1,0 +1,18 @@
+"use strict";
+const { TextEncoder, TextDecoder } = require("util");
+
+const utf8Encoder = new TextEncoder();
+const utf8Decoder = new TextDecoder("utf-8", { ignoreBOM: true });
+
+function utf8Encode(string) {
+  return utf8Encoder.encode(string);
+}
+
+function utf8DecodeWithoutBOM(bytes) {
+  return utf8Decoder.decode(bytes);
+}
+
+module.exports = {
+  utf8Encode,
+  utf8DecodeWithoutBOM
+};

--- a/src/infra.js
+++ b/src/infra.js
@@ -1,5 +1,7 @@
 "use strict";
 
+// Note that we take code points as JS numbers, not JS strings.
+
 function isASCIIDigit(c) {
   return c >= 0x30 && c <= 0x39;
 }

--- a/src/percent-encoding.js
+++ b/src/percent-encoding.js
@@ -1,0 +1,139 @@
+"use strict";
+const { isASCIIHex } = require("./infra");
+const { utf8Encode } = require("./encoding");
+
+function p(char) {
+  return char.codePointAt(0);
+}
+
+// https://whatpr.org/url/518.html#percent-encode
+function percentEncode(c) {
+  let hex = c.toString(16).toUpperCase();
+  if (hex.length === 1) {
+    hex = "0" + hex;
+  }
+
+  return "%" + hex;
+}
+
+// https://whatpr.org/url/518.html#percent-decode
+function percentDecodeBytes(input) {
+  const output = new Uint8Array(input.byteLength);
+  let outputIndex = 0;
+  for (let i = 0; i < input.byteLength; ++i) {
+    const byte = input[i];
+    if (byte !== 0x25) {
+      output[outputIndex++] = byte;
+    } else if (byte === 0x25 && (!isASCIIHex(input[i + 1]) || !isASCIIHex(input[i + 2]))) {
+      output[outputIndex++] = byte;
+    } else {
+      const bytePoint = parseInt(String.fromCodePoint(input[i + 1], input[i + 2]), 16);
+      output[outputIndex++] = bytePoint;
+      i += 2;
+    }
+  }
+
+  return output.slice(0, outputIndex);
+}
+
+// https://whatpr.org/url/518.html#string-percent-decode
+function percentDecodeString(input) {
+  const bytes = utf8Encode(input);
+  return percentDecodeBytes(bytes);
+}
+
+// https://whatpr.org/url/518.html#c0-control-percent-encode-set
+function isC0ControlPercentEncode(c) {
+  return c <= 0x1F || c > 0x7E;
+}
+
+// https://whatpr.org/url/518.html#fragment-percent-encode-set
+const extraFragmentPercentEncodeSet = new Set([p(" "), p("\""), p("<"), p(">"), p("`")]);
+function isFragmentPercentEncode(c) {
+  return isC0ControlPercentEncode(c) || extraFragmentPercentEncodeSet.has(c);
+}
+
+// https://whatpr.org/url/518.html#query-percent-encode-set
+const extraQueryPercentEncodeSet = new Set([p(" "), p("\""), p("#"), p("<"), p(">")]);
+function isQueryPercentEncode(c) {
+  return isC0ControlPercentEncode(c) || extraQueryPercentEncodeSet.has(c);
+}
+
+// https://whatpr.org/url/518.html#special-query-percent-encode-set
+function isSpecialQueryPercentEncode(c) {
+  return isQueryPercentEncode(c) || c === p("'");
+}
+
+// https://whatpr.org/url/518.html#path-percent-encode-set
+const extraPathPercentEncodeSet = new Set([p("?"), p("`"), p("{"), p("}")]);
+function isPathPercentEncode(c) {
+  return isQueryPercentEncode(c) || extraPathPercentEncodeSet.has(c);
+}
+
+// https://whatpr.org/url/518.html#userinfo-percent-encode-set
+const extraUserinfoPercentEncodeSet =
+  new Set([p("/"), p(":"), p(";"), p("="), p("@"), p("["), p("\\"), p("]"), p("^"), p("|")]);
+function isUserinfoPercentEncode(c) {
+  return isPathPercentEncode(c) || extraUserinfoPercentEncodeSet.has(c);
+}
+
+// https://whatpr.org/url/518.html#application-x-www-form-urlencoded-percent-encode-set
+const extraURLEncodedPercentEncodeSet = new Set([
+  p("!"), p("$"), p("%"), p("&"), p("'"),
+  p("("), p(")"), p("+"), p(","), p("~")
+]);
+function isURLEncodedPercentEncode(c) {
+  return isUserinfoPercentEncode(c) || extraURLEncodedPercentEncodeSet.has(c);
+}
+
+// https://whatpr.org/url/518.html#code-point-percent-encode-after-encoding
+// https://whatpr.org/url/518.html#utf-8-percent-encode
+// Assuming encoding is always utf-8 allows us to trim one of the logic branches. TODO: support encoding.
+// The "-Internal" variant here has code points as JS strings. The external version used by other files has code points
+// as JS numbers, like the rest of the codebase.
+function utf8PercentEncodeCodePointInternal(codePoint, percentEncodePredicate) {
+  const bytes = utf8Encode(codePoint);
+  let output = "";
+  for (const byte of bytes) {
+    // Our percentEncodePredicate operates on bytes, not code points, so this is slightly different from the spec.
+    if (!percentEncodePredicate(byte)) {
+      output += String.fromCharCode(byte);
+    } else {
+      output += percentEncode(byte);
+    }
+  }
+
+  return output;
+}
+
+function utf8PercentEncodeCodePoint(codePoint, percentEncodePredicate) {
+  return utf8PercentEncodeCodePointInternal(String.fromCodePoint(codePoint), percentEncodePredicate);
+}
+
+// https://whatpr.org/url/518.html#string-percent-encode-after-encoding
+// https://whatpr.org/url/518.html#string-utf-8-percent-encode
+function utf8PercentEncodeString(input, percentEncodePredicate, spaceAsPlus = false) {
+  let output = "";
+  for (const codePoint of input) {
+    if (spaceAsPlus && codePoint === " ") {
+      output += "+";
+    } else {
+      output += utf8PercentEncodeCodePointInternal(codePoint, percentEncodePredicate);
+    }
+  }
+  return output;
+}
+
+module.exports = {
+  isC0ControlPercentEncode,
+  isFragmentPercentEncode,
+  isQueryPercentEncode,
+  isSpecialQueryPercentEncode,
+  isPathPercentEncode,
+  isUserinfoPercentEncode,
+  isURLEncodedPercentEncode,
+  percentDecodeString,
+  percentDecodeBytes,
+  utf8PercentEncodeString,
+  utf8PercentEncodeCodePoint
+};

--- a/src/urlencoded.js
+++ b/src/urlencoded.js
@@ -1,8 +1,80 @@
 "use strict";
-const { isASCIIHex } = require("./infra");
+const { utf8Encode, utf8DecodeWithoutBOM } = require("./encoding");
+const { percentDecodeBytes, utf8PercentEncodeString, isURLEncodedPercentEncode } = require("./percent-encoding");
 
 function p(char) {
   return char.codePointAt(0);
+}
+
+// https://whatpr.org/url/518.html#concept-urlencoded-parser
+function parseUrlencoded(input) {
+  const sequences = strictlySplitByteSequence(input, p("&"));
+  const output = [];
+  for (const bytes of sequences) {
+    if (bytes.length === 0) {
+      continue;
+    }
+
+    let name;
+    let value;
+    const indexOfEqual = bytes.indexOf(p("="));
+
+    if (indexOfEqual >= 0) {
+      name = bytes.slice(0, indexOfEqual);
+      value = bytes.slice(indexOfEqual + 1);
+    } else {
+      name = bytes;
+      value = new Uint8Array(0);
+    }
+
+    name = replaceByteInByteSequence(name, 0x2B, 0x20);
+    value = replaceByteInByteSequence(value, 0x2B, 0x20);
+
+    const nameString = utf8DecodeWithoutBOM(percentDecodeBytes(name));
+    const valueString = utf8DecodeWithoutBOM(percentDecodeBytes(value));
+
+    output.push([nameString, valueString]);
+  }
+  return output;
+}
+
+// https://whatpr.org/url/518.html#concept-urlencoded-string-parser
+function parseUrlencodedString(input) {
+  return parseUrlencoded(utf8Encode(input));
+}
+
+// https://whatpr.org/url/518.html#concept-urlencoded-serializer
+function serializeUrlencoded(tuples, encodingOverride = undefined) {
+  let encoding = "utf-8";
+  if (encodingOverride !== undefined) {
+    // TODO "get the output encoding", i.e. handle encoding labels vs. names.
+    encoding = encodingOverride;
+  }
+
+  let output = "";
+  for (const [i, tuple] of tuples.entries()) {
+    // TODO: handle encoding override
+
+    const name = utf8PercentEncodeString(tuple[0], isURLEncodedPercentEncode, true);
+
+    let value = tuple[1];
+    if (tuple.length > 2 && tuple[2] !== undefined) {
+      if (tuple[2] === "hidden" && name === "_charset_") {
+        value = encoding;
+      } else if (tuple[2] === "file") {
+        // value is a File object
+        value = value.name;
+      }
+    }
+
+    value = utf8PercentEncodeString(value, isURLEncodedPercentEncode, true);
+
+    if (i !== 0) {
+      output += "&";
+    }
+    output += `${name}=${value}`;
+  }
+  return output;
 }
 
 function strictlySplitByteSequence(buf, cp) {
@@ -29,114 +101,7 @@ function replaceByteInByteSequence(buf, from, to) {
   return buf;
 }
 
-function percentEncode(c) {
-  let hex = c.toString(16).toUpperCase();
-  if (hex.length === 1) {
-    hex = "0" + hex;
-  }
-
-  return "%" + hex;
-}
-
-function percentDecode(input) {
-  const output = Buffer.alloc(input.byteLength);
-  let ptr = 0;
-  for (let i = 0; i < input.length; ++i) {
-    if (input[i] !== p("%") || !isASCIIHex(input[i + 1]) || !isASCIIHex(input[i + 2])) {
-      output[ptr++] = input[i];
-    } else {
-      output[ptr++] = parseInt(input.slice(i + 1, i + 3).toString(), 16);
-      i += 2;
-    }
-  }
-  return output.slice(0, ptr);
-}
-
-function parseUrlencoded(input) {
-  const sequences = strictlySplitByteSequence(input, p("&"));
-  const output = [];
-  for (const bytes of sequences) {
-    if (bytes.length === 0) {
-      continue;
-    }
-
-    let name;
-    let value;
-    const indexOfEqual = bytes.indexOf(p("="));
-
-    if (indexOfEqual >= 0) {
-      name = bytes.slice(0, indexOfEqual);
-      value = bytes.slice(indexOfEqual + 1);
-    } else {
-      name = bytes;
-      value = Buffer.alloc(0);
-    }
-
-    name = replaceByteInByteSequence(Buffer.from(name), p("+"), p(" "));
-    value = replaceByteInByteSequence(Buffer.from(value), p("+"), p(" "));
-
-    output.push([percentDecode(name).toString(), percentDecode(value).toString()]);
-  }
-  return output;
-}
-
-function serializeUrlencodedByte(input) {
-  let output = "";
-  for (const byte of input) {
-    if (byte === p(" ")) {
-      output += "+";
-    } else if (byte === p("*") ||
-               byte === p("-") ||
-               byte === p(".") ||
-               (byte >= p("0") && byte <= p("9")) ||
-               (byte >= p("A") && byte <= p("Z")) ||
-               byte === p("_") ||
-               (byte >= p("a") && byte <= p("z"))) {
-      output += String.fromCodePoint(byte);
-    } else {
-      output += percentEncode(byte);
-    }
-  }
-  return output;
-}
-
-function serializeUrlencoded(tuples, encodingOverride = undefined) {
-  let encoding = "utf-8";
-  if (encodingOverride !== undefined) {
-    encoding = encodingOverride;
-  }
-
-  let output = "";
-  for (const [i, tuple] of tuples.entries()) {
-    // TODO: handle encoding override
-    const name = serializeUrlencodedByte(Buffer.from(tuple[0]));
-    let value = tuple[1];
-    if (tuple.length > 2 && tuple[2] !== undefined) {
-      if (tuple[2] === "hidden" && name === "_charset_") {
-        value = encoding;
-      } else if (tuple[2] === "file") {
-        // value is a File object
-        value = value.name;
-      }
-    }
-    value = serializeUrlencodedByte(Buffer.from(value));
-    if (i !== 0) {
-      output += "&";
-    }
-    output += `${name}=${value}`;
-  }
-  return output;
-}
-
 module.exports = {
-  percentEncode,
-  percentDecode,
-
-  // application/x-www-form-urlencoded string parser
-  parseUrlencoded(input) {
-    return parseUrlencoded(Buffer.from(input));
-  },
-
-  // application/x-www-form-urlencoded serializer
+  parseUrlencodedString,
   serializeUrlencoded
 };


### PR DESCRIPTION
Follows https://github.com/whatwg/url/pull/518.

This generally tries to make the code correspond more explicitly to the specification in a few ways. It doesn't handle non-UTF-8 encodings yet, though.

Supersedes #152. /cc @annevk.