### PR TITLE
Spec update: add the component percent-encode set

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 ﻿# whatwg-url
 
-whatwg-url is a full implementation of the WHATWG [URL Standard](https://url.spec.whatwg.org/). It can be used standalone, but it also exposes a lot of the internal algorithms that are useful for integrating a URL parser into a project like [jsdom](https://github.com/tmpvar/jsdom).
+whatwg-url is a full implementation of the WHATWG [URL Standard](https://url.spec.whatwg.org/). It can be used standalone, but it also exposes a lot of the internal algorithms that are useful for integrating a URL parser into a project like [jsdom](https://github.com/jsdom/jsdom).
 
 ## Specification conformance
 
-whatwg-url is currently up to date with the URL spec up to commit [cb9c97f](https://github.com/whatwg/url/commit/cb9c97f3b539899197e0648c252cea75394262d6).
+whatwg-url is currently up to date with the URL spec up to commit [975614e](https://github.com/whatwg/url/commit/975614edeee28628298d39af174e9a276366de4f).
 
 For `file:` URLs, whose [origin is left unspecified](https://url.spec.whatwg.org/#concept-url-origin), whatwg-url chooses to use a new opaque origin (which serializes to `"null"`).
 

--- a/scripts/get-latest-platform-tests.js
+++ b/scripts/get-latest-platform-tests.js
@@ -24,7 +24,7 @@ process.on("unhandledRejection", err => {
 // 1. Go to https://github.com/w3c/web-platform-tests/tree/master/url
 // 2. Press "y" on your keyboard to get a permalink
 // 3. Copy the commit hash
-const commitHash = "9ffe8f26432649d02eb81add2816dd5394f57a8c";
+const commitHash = "6c74b7e43c9a1f6dc3dc529e427e2ef96152409e";
 
 const urlPrefix = `https://raw.githubusercontent.com/web-platform-tests/wpt/${commitHash}/url/`;
 const targetDir = path.resolve(__dirname, "..", "test", "web-platform-tests");

--- a/src/percent-encoding.js
+++ b/src/percent-encoding.js
@@ -6,7 +6,7 @@ function p(char) {
   return char.codePointAt(0);
 }
 
-// https://whatpr.org/url/518.html#percent-encode
+// https://url.spec.whatwg.org/#percent-encode
 function percentEncode(c) {
   let hex = c.toString(16).toUpperCase();
   if (hex.length === 1) {
@@ -16,7 +16,7 @@ function percentEncode(c) {
   return "%" + hex;
 }
 
-// https://whatpr.org/url/518.html#percent-decode
+// https://url.spec.whatwg.org/#percent-decode
 function percentDecodeBytes(input) {
   const output = new Uint8Array(input.byteLength);
   let outputIndex = 0;
@@ -36,58 +36,61 @@ function percentDecodeBytes(input) {
   return output.slice(0, outputIndex);
 }
 
-// https://whatpr.org/url/518.html#string-percent-decode
+// https://url.spec.whatwg.org/#string-percent-decode
 function percentDecodeString(input) {
   const bytes = utf8Encode(input);
   return percentDecodeBytes(bytes);
 }
 
-// https://whatpr.org/url/518.html#c0-control-percent-encode-set
+// https://url.spec.whatwg.org/#c0-control-percent-encode-set
 function isC0ControlPercentEncode(c) {
   return c <= 0x1F || c > 0x7E;
 }
 
-// https://whatpr.org/url/518.html#fragment-percent-encode-set
+// https://url.spec.whatwg.org/#fragment-percent-encode-set
 const extraFragmentPercentEncodeSet = new Set([p(" "), p("\""), p("<"), p(">"), p("`")]);
 function isFragmentPercentEncode(c) {
   return isC0ControlPercentEncode(c) || extraFragmentPercentEncodeSet.has(c);
 }
 
-// https://whatpr.org/url/518.html#query-percent-encode-set
+// https://url.spec.whatwg.org/#query-percent-encode-set
 const extraQueryPercentEncodeSet = new Set([p(" "), p("\""), p("#"), p("<"), p(">")]);
 function isQueryPercentEncode(c) {
   return isC0ControlPercentEncode(c) || extraQueryPercentEncodeSet.has(c);
 }
 
-// https://whatpr.org/url/518.html#special-query-percent-encode-set
+// https://url.spec.whatwg.org/#special-query-percent-encode-set
 function isSpecialQueryPercentEncode(c) {
   return isQueryPercentEncode(c) || c === p("'");
 }
 
-// https://whatpr.org/url/518.html#path-percent-encode-set
+// https://url.spec.whatwg.org/#path-percent-encode-set
 const extraPathPercentEncodeSet = new Set([p("?"), p("`"), p("{"), p("}")]);
 function isPathPercentEncode(c) {
   return isQueryPercentEncode(c) || extraPathPercentEncodeSet.has(c);
 }
 
-// https://whatpr.org/url/518.html#userinfo-percent-encode-set
+// https://url.spec.whatwg.org/#userinfo-percent-encode-set
 const extraUserinfoPercentEncodeSet =
   new Set([p("/"), p(":"), p(";"), p("="), p("@"), p("["), p("\\"), p("]"), p("^"), p("|")]);
 function isUserinfoPercentEncode(c) {
   return isPathPercentEncode(c) || extraUserinfoPercentEncodeSet.has(c);
 }
 
-// https://whatpr.org/url/518.html#application-x-www-form-urlencoded-percent-encode-set
-const extraURLEncodedPercentEncodeSet = new Set([
-  p("!"), p("$"), p("%"), p("&"), p("'"),
-  p("("), p(")"), p("+"), p(","), p("~")
-]);
-function isURLEncodedPercentEncode(c) {
-  return isUserinfoPercentEncode(c) || extraURLEncodedPercentEncodeSet.has(c);
+// https://url.spec.whatwg.org/#component-percent-encode-set
+const extraComponentPercentEncodeSet = new Set([p("$"), p("%"), p("&"), p("+"), p(",")]);
+function isComponentPercentEncode(c) {
+  return isUserinfoPercentEncode(c) || extraComponentPercentEncodeSet.has(c);
 }
 
-// https://whatpr.org/url/518.html#code-point-percent-encode-after-encoding
-// https://whatpr.org/url/518.html#utf-8-percent-encode
+// https://url.spec.whatwg.org/#application-x-www-form-urlencoded-percent-encode-set
+const extraURLEncodedPercentEncodeSet = new Set([p("!"), p("'"), p("("), p(")"), p("~")]);
+function isURLEncodedPercentEncode(c) {
+  return isComponentPercentEncode(c) || extraURLEncodedPercentEncodeSet.has(c);
+}
+
+// https://url.spec.whatwg.org/#code-point-percent-encode-after-encoding
+// https://url.spec.whatwg.org/#utf-8-percent-encode
 // Assuming encoding is always utf-8 allows us to trim one of the logic branches. TODO: support encoding.
 // The "-Internal" variant here has code points as JS strings. The external version used by other files has code points
 // as JS numbers, like the rest of the codebase.
@@ -110,8 +113,8 @@ function utf8PercentEncodeCodePoint(codePoint, percentEncodePredicate) {
   return utf8PercentEncodeCodePointInternal(String.fromCodePoint(codePoint), percentEncodePredicate);
 }
 
-// https://whatpr.org/url/518.html#string-percent-encode-after-encoding
-// https://whatpr.org/url/518.html#string-utf-8-percent-encode
+// https://url.spec.whatwg.org/#string-percent-encode-after-encoding
+// https://url.spec.whatwg.org/#string-utf-8-percent-encode
 function utf8PercentEncodeString(input, percentEncodePredicate, spaceAsPlus = false) {
   let output = "";
   for (const codePoint of input) {

--- a/src/urlencoded.js
+++ b/src/urlencoded.js
@@ -6,7 +6,7 @@ function p(char) {
   return char.codePointAt(0);
 }
 
-// https://whatpr.org/url/518.html#concept-urlencoded-parser
+// https://url.spec.whatwg.org/#concept-urlencoded-parser
 function parseUrlencoded(input) {
   const sequences = strictlySplitByteSequence(input, p("&"));
   const output = [];
@@ -38,12 +38,12 @@ function parseUrlencoded(input) {
   return output;
 }
 
-// https://whatpr.org/url/518.html#concept-urlencoded-string-parser
+// https://url.spec.whatwg.org/#concept-urlencoded-string-parser
 function parseUrlencodedString(input) {
   return parseUrlencoded(utf8Encode(input));
 }
 
-// https://whatpr.org/url/518.html#concept-urlencoded-serializer
+// https://url.spec.whatwg.org/#concept-urlencoded-serializer
 function serializeUrlencoded(tuples, encodingOverride = undefined) {
   let encoding = "utf-8";
   if (encodingOverride !== undefined) {


### PR DESCRIPTION
This has no observable behavior changes and the component percent-encode set isn't even used by the rest of the implementation directly. However, it keeps us in sync with the spec, and it isn't totally dead code since it is used indirectly.

Also fixes various spec URLs in comments that were accidentally left pointing a PR preview in cf7a7c1c29f6853faf79f50c97e0767da2182a52.