### PR TITLE
Fix percentDecode to return a Buffer instead of a Uint8Array

### DIFF
--- a/src/percent-encoding.js
+++ b/src/percent-encoding.js
@@ -33,7 +33,10 @@ function percentDecodeBytes(input) {
     }
   }
 
-  return output.slice(0, outputIndex);
+  // TODO: remove the Buffer.from in the next major version; it's only needed for back-compat, and sticking to standard
+  // typed arrays is nicer and simpler.
+  // See https://github.com/jsdom/data-urls/issues/17 for background.
+  return Buffer.from(output.slice(0, outputIndex));
 }
 
 // https://url.spec.whatwg.org/#string-percent-decode


### PR DESCRIPTION
This regressed in v8.2.0. Closes https://github.com/jsdom/data-urls/issues/17. Closes https://github.com/jsdom/data-urls/pull/18.