### PR TITLE
Spec update: refactor query state

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@ whatwg-url is a full implementation of the WHATWG [URL Standard](https://url.spe
 
 ## Specification conformance
 
-whatwg-url is currently up to date with the URL spec up to commit [a19495e](https://github.com/whatwg/url/commit/a19495e27ad95154543b46f751d1a1bf25553808).
+whatwg-url is currently up to date with the URL spec up to commit [2ce4938](https://github.com/whatwg/url/commit/2ce49383db3506a3c1a527a775693af1100198ef).
 
 For `file:` URLs, whose [origin is left unspecified](https://url.spec.whatwg.org/#concept-url-origin), whatwg-url chooses to use a new opaque origin (which serializes to `"null"`).
+
+whatwg-url does not yet implement any encoding handling beyond UTF-8. That is, the _encoding override_ parameter does not exist in our API.
 
 ## API
 
@@ -18,8 +20,8 @@ The main API is provided by the [`URL`](https://url.spec.whatwg.org/#url-class) 
 
 The following methods are exported for use by places like jsdom that need to implement things like [`HTMLHyperlinkElementUtils`](https://html.spec.whatwg.org/#htmlhyperlinkelementutils). They mostly operate on or return an "internal URL" or ["URL record"](https://url.spec.whatwg.org/#concept-url) type.
 
-- [URL parser](https://url.spec.whatwg.org/#concept-url-parser): `parseURL(input, { baseURL, encodingOverride })`
-- [Basic URL parser](https://url.spec.whatwg.org/#concept-basic-url-parser): `basicURLParse(input, { baseURL, encodingOverride, url, stateOverride })`
+- [URL parser](https://url.spec.whatwg.org/#concept-url-parser): `parseURL(input, { baseURL })`
+- [Basic URL parser](https://url.spec.whatwg.org/#concept-basic-url-parser): `basicURLParse(input, { baseURL, url, stateOverride })`
 - [URL serializer](https://url.spec.whatwg.org/#concept-url-serializer): `serializeURL(urlRecord, excludeFragment)`
 - [Host serializer](https://url.spec.whatwg.org/#concept-host-serializer): `serializeHost(hostFromURLRecord)`
 - [Serialize an integer](https://url.spec.whatwg.org/#serialize-an-integer): `serializeInteger(number)`


### PR DESCRIPTION
Follows https://github.com/whatwg/url/pull/558.

This also updates the documentation to make it clear that we have no encoding handling, and removes the mention of encodingOverride (which was ignored by the code).