### PR TITLE
dep: reduce size of consumer node_modules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4217,8 +4217,7 @@
     "lodash": {
       "version": "4.17.20",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
-      "dev": true
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
     },
     "lodash.memoize": {
       "version": "3.0.4",
@@ -4229,7 +4228,8 @@
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+      "dev": true
     },
     "lowercase-keys": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "license": "MIT",
   "repository": "jsdom/whatwg-url",
   "dependencies": {
-    "lodash.sortby": "^4.7.0",
+    "lodash": "^4.7.0",
     "tr46": "^2.0.2",
     "webidl-conversions": "^6.1.0"
   },

--- a/src/URLSearchParams-impl.js
+++ b/src/URLSearchParams-impl.js
@@ -1,5 +1,5 @@
 "use strict";
-const stableSortBy = require("lodash.sortby");
+const stableSortBy = require("lodash/sortBy");
 const urlencoded = require("./urlencoded");
 
 exports.implementation = class URLSearchParamsImpl {


### PR DESCRIPTION
## Summary

Reduce size of users dependency tree

Most of users already has lodash installed as its a dependency of thousands of packages
When i look at mine, I see 50 different versions of submodules,

This is also recommended action from lodash: https://lodash.com/per-method-packages and per method packages will no longer be available in v5

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

