### PR TITLE
Replace full lodash install with lodash.sortby

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "version": "8.5.0",
       "license": "MIT",
       "dependencies": {
-        "lodash": "^4.7.0",
+        "lodash.sortby": "^4.7.0",
         "tr46": "^2.0.2",
         "webidl-conversions": "^6.1.0"
       },
@@ -5348,7 +5348,8 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "node_modules/lodash.memoize": {
       "version": "3.0.4",
@@ -5359,8 +5360,7 @@
     "node_modules/lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
-      "dev": true
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
     },
     "node_modules/lowercase-keys": {
       "version": "2.0.0",
@@ -13067,7 +13067,8 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "lodash.memoize": {
       "version": "3.0.4",
@@ -13078,8 +13079,7 @@
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
-      "dev": true
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
     },
     "lowercase-keys": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "license": "MIT",
   "repository": "jsdom/whatwg-url",
   "dependencies": {
-    "lodash": "^4.7.0",
+    "lodash.sortby": "^4.7.0",
     "tr46": "^2.0.2",
     "webidl-conversions": "^6.1.0"
   },

--- a/src/URLSearchParams-impl.js
+++ b/src/URLSearchParams-impl.js
@@ -1,5 +1,5 @@
 "use strict";
-const stableSortBy = require("lodash/sortBy");
+const stableSortBy = require("lodash.sortBy");
 const urlencoded = require("./urlencoded");
 
 exports.implementation = class URLSearchParamsImpl {


### PR DESCRIPTION
This should reduce install size for projects that do not have full `lodash` anywhere in their dependency tree.