### PR TITLE
Fix the live URL viewer in Safari

### DIFF
--- a/live-viewer/index.html
+++ b/live-viewer/index.html
@@ -4,10 +4,16 @@
 <link rel="stylesheet" href="style.css">
 
 <script>
-// whatwg-url.js depends on SharedArrayBuffer being global, but we can't set COOP+COEP headers on
-// GitHub pages.
-window.SharedArrayBuffer =
-  new WebAssembly.Memory({ shared:true, initial:1, maximum:1 }).buffer.constructor;
+// whatwg-url.js depends on SharedArrayBuffer.prototype.byteLength having a getter, but Safari
+// doesn't support SharedArrayBuffer. Since the dependency is just for type-checking code in
+// https://github.com/jsdom/webidl-conversions which isn't actually exercised, we can stub it out.
+if (!window.SharedArrayBuffer) {
+  window.SharedArrayBuffer = {
+    prototype: {
+      get byteLength() { }
+    }
+  };
+}
 </script>
 <script src="whatwg-url.js"></script>
 


### PR DESCRIPTION
Closes #187.