### PR TITLE
Bump webidl-conversions to 7.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,11 +5,12 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "whatwg-url",
       "version": "9.1.0",
       "license": "MIT",
       "dependencies": {
         "tr46": "^2.1.0",
-        "webidl-conversions": "^6.1.0"
+        "webidl-conversions": "^7.0.0"
       },
       "devDependencies": {
         "@domenic/eslint-config": "^1.2.0",
@@ -4689,6 +4690,15 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/jsdom/node_modules/webidl-conversions": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
+      "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.4"
+      }
+    },
     "node_modules/jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -6634,11 +6644,11 @@
       }
     },
     "node_modules/webidl-conversions": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
-      "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
       "engines": {
-        "node": ">=10.4"
+        "node": ">=12"
       }
     },
     "node_modules/webidl2": {
@@ -6659,6 +6669,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/webidl2js/node_modules/webidl-conversions": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
+      "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.4"
       }
     },
     "node_modules/whatwg-encoding": {
@@ -6688,6 +6707,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/whatwg-url/node_modules/webidl-conversions": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
+      "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.4"
       }
     },
     "node_modules/which": {
@@ -10563,6 +10591,12 @@
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.4.1.tgz",
           "integrity": "sha512-asabaBSkEKosYKMITunzX177CXxQ4Q8BSSzMTKD+FefUhipQC70gfW5SiUDhYQ3vk8G+81HqQk7Fv9OXwwn9KA==",
           "dev": true
+        },
+        "webidl-conversions": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
+          "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==",
+          "dev": true
         }
       }
     },
@@ -12126,9 +12160,9 @@
       }
     },
     "webidl-conversions": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
-      "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w=="
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="
     },
     "webidl2": {
       "version": "23.13.1",
@@ -12145,6 +12179,14 @@
         "prettier": "^2.0.4",
         "webidl-conversions": "^6.1.0",
         "webidl2": "^23.12.1"
+      },
+      "dependencies": {
+        "webidl-conversions": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
+          "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==",
+          "dev": true
+        }
       }
     },
     "whatwg-encoding": {
@@ -12171,6 +12213,14 @@
         "lodash": "^4.7.0",
         "tr46": "^2.1.0",
         "webidl-conversions": "^6.1.0"
+      },
+      "dependencies": {
+        "webidl-conversions": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
+          "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==",
+          "dev": true
+        }
       }
     },
     "which": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "repository": "jsdom/whatwg-url",
   "dependencies": {
     "tr46": "^2.1.0",
-    "webidl-conversions": "^6.1.0"
+    "webidl-conversions": "^7.0.0"
   },
   "devDependencies": {
     "@domenic/eslint-config": "^1.2.0",


### PR DESCRIPTION
Update to webidl-conversions@7.0.0 to support environments without `SharedArrayBuffer`.

We dropped support for Node.js v10 (https://github.com/jsdom/whatwg-url/commit/08e598877a57b077247a19dfa1a82104c636a075) a few months ago, so this is not conflicting with this lib requirement.

### Release Note

>Bumped Node.js version requirement to ≥12.
>
>Removed `Function` and `VoidFunction` exports. These are better handled by [`webidl2js`](https://github.com/jsdom/webidl2js).
>
>Renamed the `void` export to `undefined`, per Web IDL spec updates.
>
>Added support for environments without `SharedArrayBuffer`.
>
>Fixed a typo in one of the exception messages for `BufferSource`.