### PR TITLE
fixed `ReferenceError: TextEncoder is not defined` error

### DIFF
--- a/lib/encoding.js
+++ b/lib/encoding.js
@@ -1,4 +1,5 @@
 "use strict";
+const { TextEncoder, TextDecoder } = require("util");
 const utf8Encoder = new TextEncoder();
 const utf8Decoder = new TextDecoder("utf-8", { ignoreBOM: true });
 


### PR DESCRIPTION
The latest version threw 
```
const utf8Encoder = new TextEncoder();
                    ^
ReferenceError: TextEncoder is not defined
```
exception repeatedly. This commit fixes that.