### PR TITLE
Live viewer: fix empty string URL inputs in shared links

### DIFF
--- a/live-viewer/live-viewer.js
+++ b/live-viewer/live-viewer.js
@@ -116,7 +116,7 @@
   }
 
   function setFromFragment() {
-    const pieces = /#url=([^&]+)&base=(.*)/u.exec(location.hash);
+    const pieces = /#url=([^&]*)&base=(.*)/u.exec(location.hash);
     if (!pieces) {
       return;
     }


### PR DESCRIPTION
Discovered in https://github.com/whatwg/url/issues/677#issuecomment-993752115.