### PR TITLE
import TextEncoder and TextDecoder

### DIFF
--- a/lib/encoding.js
+++ b/lib/encoding.js
@@ -1,4 +1,6 @@
 "use strict";
+const { TextEncoder, TextDecoder } = require("util")
+
 const utf8Encoder = new TextEncoder();
 const utf8Decoder = new TextDecoder("utf-8", { ignoreBOM: true });
 


### PR DESCRIPTION
When run at node server display "TextEncoder is not defined", that's imports fix this issue. 