### PR TITLE
Updated encoding.js

### DIFF
--- a/lib/encoding.js
+++ b/lib/encoding.js
@@ -1,4 +1,5 @@
 "use strict";
+const { TextEncoder, TextDecoder } = require("util");
 const utf8Encoder = new TextEncoder();
 const utf8Decoder = new TextDecoder("utf-8", { ignoreBOM: true });
 


### PR DESCRIPTION
Received error "TextEncoder is not defined" when using Mongoose in Node.js

Added require("util") to enable functionality.