### PR TITLE
Reference Error Fix

### DIFF
--- a/lib/encoding.js
+++ b/lib/encoding.js
@@ -1,4 +1,7 @@
 "use strict";
+
+const { TextEncoder, TextDecoder } = require('util')
+
 const utf8Encoder = new TextEncoder();
 const utf8Decoder = new TextDecoder("utf-8", { ignoreBOM: true });
 


### PR DESCRIPTION
Because the require was missing my ubuntu node api was failing with a reference error. This package is a requirement of another module 'mongo-connection-string-url' which was a requirement of 'agenda'. Including the line in this commit fixed the error.