### PR TITLE
add single dot host test

### DIFF
--- a/test/single-dot-host-test.js
+++ b/test/single-dot-host-test.js
@@ -1,0 +1,8 @@
+"use strict";
+const assert = require("assert");
+const { URL } = require("..");
+
+test("new URL gives a null origin for file URLs", () => {
+  const url = new URL("h://.");
+  assert.strictEqual(url.host, ".");
+});


### PR DESCRIPTION
I suspect Chrome and Firefox are not following non-special URL when the host is a single-byte `.` character.

non-special:
https://jsdom.github.io/whatwg-url/#url=aDovLy4=&base=YWJvdXQ6Ymxhbms=

special:
https://jsdom.github.io/whatwg-url/#url=aHR0cDovLy4=&base=YWJvdXQ6Ymxhbms=

Related to https://github.com/jsdom/whatwg-url/pull/82

By following https://url.spec.whatwg.org/# I think standard and implementation in this repository is correct and `.` should be returned.

wpt repository only has special test case.
https://github.com/web-platform-tests/wpt/blob/2a64dae4641fbd61bd4257df460e188f425b492e/url/resources/urltestdata.json#L3889-L3919