### PR TITLE
Remove DOMException dev dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "@domenic/eslint-config": "^3.0.0",
         "benchmark": "^2.1.4",
         "c8": "^8.0.1",
-        "domexception": "^4.0.0",
         "esbuild": "^0.19.5",
         "eslint": "^8.53.0",
         "webidl2js": "^17.1.0"
@@ -806,18 +805,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/domexception": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
-      "integrity": "sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==",
-      "dev": true,
-      "dependencies": {
-        "webidl-conversions": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/emoji-regex": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "@domenic/eslint-config": "^3.0.0",
     "benchmark": "^2.1.4",
     "c8": "^8.0.1",
-    "domexception": "^4.0.0",
     "esbuild": "^0.19.5",
     "eslint": "^8.53.0",
     "webidl2js": "^17.1.0"

--- a/test/testharness.js
+++ b/test/testharness.js
@@ -34,8 +34,8 @@ module.exports = {
   },
 
   assert_throws_js(errorConstructor, func) {
-    // Don't bother testing the errorConstructor since that brings in tricky realm issues.
-    assert.throws(func);
+    // Don't pass errorConstructor itself since that brings in tricky realm issues.
+    assert.throws(func, errorConstructor.name);
   },
 
   assert_unreached() {

--- a/test/web-platform.js
+++ b/test/web-platform.js
@@ -4,7 +4,6 @@ const path = require("path");
 const fs = require("fs");
 const vm = require("vm");
 const assert = require("assert");
-const DOMException = require("domexception");
 const { directlyRunnableTests, resourceDependentTests } = require("../scripts/get-latest-platform-tests.js");
 const testharness = require("./testharness.js");
 


### PR DESCRIPTION
Node.js v18+ has one built-in, which suffices for our purpose of running web platform tests.