### PR TITLE
Improve the regularization term

### DIFF
--- a/lib/url-state-machine.js
+++ b/lib/url-state-machine.js
@@ -442,7 +442,7 @@ function domainToASCII(domain, beStrict = false) {
 }
 
 function trimControlChars(url) {
-  return url.replace(/^[\u0000-\u001F\u0020]+|[\u0000-\u001F\u0020]+$/ug, "");
+  return url.replace(/^[\u0000-\u001F\u0020]+$/ug, "");
 }
 
 function trimTabAndNewline(url) {

--- a/lib/url-state-machine.js
+++ b/lib/url-state-machine.js
@@ -442,7 +442,7 @@ function domainToASCII(domain, beStrict = false) {
 }
 
 function trimControlChars(url) {
-  return url.replace(/^[\u0000-\u001F\u0020]+$/ug, "");
+  return url.replace(/^[\u0000-\u001F\u0020]+|(?:[^\u0000-\u001F\u0020][\u0000-\u001F\u0020]+)$/ug, "");
 }
 
 function trimTabAndNewline(url) {

--- a/lib/url-state-machine.js
+++ b/lib/url-state-machine.js
@@ -442,7 +442,7 @@ function domainToASCII(domain, beStrict = false) {
 }
 
 function trimControlChars(url) {
-  return url.replace(/^[\u0000-\u001F\u0020]+|(?:[^\u0000-\u001F\u0020][\u0000-\u001F\u0020]+)$/ug, "");
+  return url.replace(/^[\u0000-\u001F\u0020]+|(?:(?<=[^\u0000-\u001F\u0020])[\u0000-\u001F\u0020]+)$/ug, "");
 }
 
 function trimTabAndNewline(url) {


### PR DESCRIPTION
To resolve this #286 [issue](https://github.com/jsdom/whatwg-url/issues/286), it is recommended to replace the original code containing the inefficient regular expression with the following optimized version:
```js
return url.replace(/^[\u0000-\u001F\u0020]+$/ug, "");
```
![image-1](https://github.com/user-attachments/assets/f2f4f3f4-a155-4b70-9da1-1af8ba359271)
This alternative simplifies the regular expression by removing the redundant | (OR) operator, effectively resolving the inefficient backtracking behavior. This optimization prevents potential performance degradation when handling specific inputs, ensuring more efficient processing.
