### PR TITLE
Implement faster trimming of control characters

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,6 +4,7 @@ export default [
   {
     ignores: [
       "coverage/",
+      "_site/",
       "test/web-platform-tests/",
       "live-viewer/whatwg-url.mjs",
       "lib/VoidFunction.js",

--- a/lib/url-state-machine.js
+++ b/lib/url-state-machine.js
@@ -441,8 +441,20 @@ function domainToASCII(domain, beStrict = false) {
   return result;
 }
 
-function trimControlChars(url) {
-  return url.replace(/^[\u0000-\u001F\u0020]+|[\u0000-\u001F\u0020]+$/ug, "");
+function trimControlChars(string) {
+  let start = 0;
+  let end = string.length;
+  for (; start < end; ++start) {
+    if (string.charCodeAt(start) > 0x20) {
+      break;
+    }
+  }
+  for (; end > start; --end) {
+    if (string.charCodeAt(end - 1) > 0x20) {
+      break;
+    }
+  }
+  return string.substring(start, end);
 }
 
 function trimTabAndNewline(url) {

--- a/lib/url-state-machine.js
+++ b/lib/url-state-machine.js
@@ -442,6 +442,8 @@ function domainToASCII(domain, beStrict = false) {
 }
 
 function trimControlChars(string) {
+  // Avoid using regexp because of this V8 bug: https://issues.chromium.org/issues/42204424
+
   let start = 0;
   let end = string.length;
   for (; start < end; ++start) {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "prepare": "node scripts/transform.js",
     "pretest": "node scripts/get-latest-platform-tests.js && node scripts/transform.js",
     "build-live-viewer": "esbuild --bundle --format=esm --sourcemap --outfile=live-viewer/whatwg-url.mjs index.js",
-    "test": "node --test test/*.js"
+    "test": "node --test test/*.js",
+    "bench": "node scripts/benchmark.js"
   },
   "c8": {
     "reporter": [

--- a/scripts/benchmark.js
+++ b/scripts/benchmark.js
@@ -1,14 +1,13 @@
 "use strict";
 const { URL } = require("../");
 const Benchmark = require("benchmark");
-const testData = require("../test/web-platform-tests/resources/urltestdata.json");
 
+const testData = require("../test/web-platform-tests/resources/urltestdata.json");
 const testInputs = testData.filter(c => typeof c === "object").map(c => c.input);
 
-const benchmark = new Benchmark(() => {
+runBenchmark("URL constructor with WPT data", () => {
   for (const input of testInputs) {
     try {
-      // eslint-disable-next-line no-new
       new URL(input);
     } catch {
       // intentionally empty
@@ -16,5 +15,22 @@ const benchmark = new Benchmark(() => {
   }
 });
 
-benchmark.on("cycle", e => console.log(e.target.toString()));
-benchmark.run();
+runBenchmark("long input not starting or ending with control characters (GH-286)", () => {
+  try {
+    new URL("!!" + "\u0000".repeat(100000) + "A\rA");
+  } catch {
+    // intentionally empty
+  }
+});
+
+function runBenchmark(name, fn) {
+  new Benchmark(name, fn, {
+    onComplete(event) {
+      console.log(`${name}:`);
+      console.log(`  ${event.target.hz.toFixed(0)} ops/second`);
+      console.log(`  ±${event.target.stats.rme.toFixed(2)}% relative margin of error`);
+      console.log(`  ${event.target.stats.sample.length} samples`);
+      console.log("");
+    }
+  }).run();
+}

--- a/scripts/benchmark.js
+++ b/scripts/benchmark.js
@@ -8,6 +8,7 @@ const testInputs = testData.filter(c => typeof c === "object").map(c => c.input)
 runBenchmark("URL constructor with WPT data", () => {
   for (const input of testInputs) {
     try {
+      // eslint-disable-next-line no-new
       new URL(input);
     } catch {
       // intentionally empty
@@ -17,7 +18,8 @@ runBenchmark("URL constructor with WPT data", () => {
 
 runBenchmark("long input not starting or ending with control characters (GH-286)", () => {
   try {
-    new URL("!!" + "\u0000".repeat(100000) + "A\rA");
+    // eslint-disable-next-line no-new
+    new URL(`!!${"\u0000".repeat(100000)}A\rA`);
   } catch {
     // intentionally empty
   }


### PR DESCRIPTION
Due to a V8 bug (https://issues.chromium.org/issues/42204424), negative end-of-string matches are slow, as shown in #286. We can avoid triggering this slowdown for certain inputs by just implementing the trimming using loops.

Closes #286. Closes #288 by superseding it.