### PR TITLE
Update for Unicode 16 / TR46 rev 33

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ whatwg-url is a full implementation of the WHATWG [URL Standard](https://url.spe
 
 ## Specification conformance
 
-whatwg-url is currently up to date with the URL spec up to commit [da212c9](https://github.com/whatwg/url/commit/da212c98f0bba9c35aec3728bbcc13f8f3a7eb52).
+whatwg-url is currently up to date with the URL spec up to commit [cfae7c4](https://github.com/whatwg/url/commit/cfae7c4ed1851886390e132fc336b653fada9123).
 
 For `file:` URLs, whose [origin is left unspecified](https://url.spec.whatwg.org/#concept-url-origin), whatwg-url chooses to use a new opaque origin (which serializes to `"null"`).
 

--- a/lib/url-state-machine.js
+++ b/lib/url-state-machine.js
@@ -344,10 +344,6 @@ function parseHost(input, isOpaque = false) {
     return failure;
   }
 
-  if (containsForbiddenDomainCodePoint(asciiDomain)) {
-    return failure;
-  }
-
   if (endsInANumber(asciiDomain)) {
     return parseIPv4(asciiDomain);
   }
@@ -429,14 +425,25 @@ function serializeHost(host) {
 
 function domainToASCII(domain, beStrict = false) {
   const result = tr46.toASCII(domain, {
+    checkHyphens: beStrict,
     checkBidi: true,
-    checkHyphens: false,
     checkJoiners: true,
     useSTD3ASCIIRules: beStrict,
-    verifyDNSLength: beStrict
+    transitionalProcessing: false,
+    verifyDNSLength: beStrict,
+    ignoreInvalidPunycode: false
   });
-  if (result === null || result === "") {
+  if (result === null) {
     return failure;
+  }
+
+  if (!beStrict) {
+    if (result === "") {
+      return failure;
+    }
+    if (containsForbiddenDomainCodePoint(result)) {
+      return failure;
+    }
   }
   return result;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "14.1.1",
       "license": "MIT",
       "dependencies": {
-        "tr46": "^5.0.0",
+        "tr46": "^5.1.0",
         "webidl-conversions": "^7.0.0"
       },
       "devDependencies": {
@@ -2185,9 +2185,9 @@
       }
     },
     "node_modules/tr46": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.0.0.tgz",
-      "integrity": "sha512-tk2G5R2KRwBd+ZN0zaEXpmzdKyOYksXwywulIX95MBODjSzMIuQnQ3m8JxgbhnL1LeVo7lqQKsYa1O3Htl7K5g==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.0.tgz",
+      "integrity": "sha512-IUWnUK7ADYR5Sl1fZlO1INDUhVhatWl7BtJWsIhwJ0UAK7ilzzIa8uIqOO/aYVWHZPJkKbEL+362wrzoeRF7bw==",
       "license": "MIT",
       "dependencies": {
         "punycode": "^2.3.1"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "license": "MIT",
   "repository": "jsdom/whatwg-url",
   "dependencies": {
-    "tr46": "^5.0.0",
+    "tr46": "^5.1.0",
     "webidl-conversions": "^7.0.0"
   },
   "devDependencies": {

--- a/scripts/get-latest-platform-tests.js
+++ b/scripts/get-latest-platform-tests.js
@@ -13,7 +13,7 @@ const path = require("path");
 // 1. Go to https://github.com/web-platform-tests/wpt/tree/master/url
 // 2. Press "y" on your keyboard to get a permalink
 // 3. Copy the commit hash
-const commitHash = "a9fe2e77b64b0ce9aefb2ed4331c52bfa44fced4";
+const commitHash = "7c9c41aedbcd49bf96fb9e35a133293b3977b83d";
 
 const urlPrefix = `https://raw.githubusercontent.com/web-platform-tests/wpt/${commitHash}/url/`;
 const targetDir = path.resolve(__dirname, "..", "test", "web-platform-tests");
@@ -25,7 +25,8 @@ const resources = [
   "resources/toascii.json",
   "resources/urltestdata.json",
   "resources/urltestdata-javascript-only.json",
-  "resources/IdnaTestV2.json"
+  "resources/IdnaTestV2.json",
+  "resources/IdnaTestV2-removed.json"
 ];
 
 // These tests we can download and run directly in /test/web-platform.js.
@@ -54,6 +55,7 @@ exports.directlyRunnableTests = [
 // can distinguish.
 exports.resourceDependentTests = [
   "IdnaTestV2.window.js",
+  "IdnaTestV2-removed.window.js",
   "url-constructor.any.js",
   "url-origin.any.js",
   "url-setters.any.js"

--- a/test/web-platform.js
+++ b/test/web-platform.js
@@ -11,6 +11,7 @@ const { utf8PercentEncodeString, isSpecialQueryPercentEncode } = require("../lib
 const { URL, URLSearchParams } = require("..");
 
 const idnaTestV2Data = require("./web-platform-tests/resources/IdnaTestV2.json");
+const idnaTestV2RemovedData = require("./web-platform-tests/resources/IdnaTestV2-removed.json");
 const urlTestData = require("./web-platform-tests/resources/urltestdata.json");
 const urlTestDataJavaScriptOnly = require("./web-platform-tests/resources/urltestdata-javascript-only.json");
 const settersData = require("./web-platform-tests/resources/setters_tests.json");
@@ -29,6 +30,7 @@ describe("Data file-based web platform tests", () => {
       resourceDependentTests,
       [
         "IdnaTestV2.window.js",
+        "IdnaTestV2-removed.window.js",
         "url-constructor.any.js",
         "url-origin.any.js",
         "url-setters.any.js"
@@ -39,6 +41,10 @@ describe("Data file-based web platform tests", () => {
 
   runWPT("IdnaTestV2.window.js", sandbox => {
     sandbox.runTests(idnaTestV2Data);
+  });
+
+  runWPT("IdnaTestV2-removed.window.js", sandbox => {
+    sandbox.runTests(idnaTestV2RemovedData);
   });
 
   runWPT("url-constructor.any.js", sandbox => {


### PR DESCRIPTION
In addition to the dependency update on tr46, this includes a series of recent URL Standard changes:

* https://github.com/whatwg/url/commit/cd8f1d6c1ad0bab1cc8e40ad8ef6ee6626c57d57
* https://github.com/whatwg/url/commit/a6e4492001454d3d823108a4c48d77a6ad4eead5
* https://github.com/whatwg/url/commit/c3d173f3106e0e557a80e30e828edb369909e17b
* https://github.com/whatwg/url/commit/7f3e3b6866f8ef4d43562545c066e147a3f2a0b1

Closes https://github.com/jsdom/whatwg-url/issues/291.

----

Not actually mergeable yet because it doesn't include the new tr46 release, but that's coming very soon, just stuck behind a slower CI.