### PR TITLE
Track URL validation errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The main API is provided by the [`URL`](https://url.spec.whatwg.org/#url-class) 
 The following methods are exported for use by places like jsdom that need to implement things like [`HTMLHyperlinkElementUtils`](https://html.spec.whatwg.org/#htmlhyperlinkelementutils). They mostly operate on or return an "internal URL" or ["URL record"](https://url.spec.whatwg.org/#concept-url) type.
 
 - [URL parser](https://url.spec.whatwg.org/#concept-url-parser): `parseURL(input, { baseURL, encoding = "UTF-8" })`
+- URL parser with [validation errors](https://url.spec.whatwg.org/#validation-error): `parseURLWithValidationErrors(input, { baseURL, encoding = "UTF-8" })`
 - [Basic URL parser](https://url.spec.whatwg.org/#concept-basic-url-parser): `basicURLParse(input, { baseURL, url, stateOverride, encoding = "UTF-8" })`
 - [URL serializer](https://url.spec.whatwg.org/#concept-url-serializer): `serializeURL(urlRecord, excludeFragment)`
 - [Host serializer](https://url.spec.whatwg.org/#concept-host-serializer): `serializeHost(hostFromURLRecord)`
@@ -70,6 +71,15 @@ The URL record type has the following API:
 These properties should be treated with care, as in general changing them will cause the URL record to be in an inconsistent state until the appropriate invocation of `basicURLParse` is used to fix it up. You can see examples of this in the URL Standard, where there are many step sequences like "4. Set context object’s url’s fragment to the empty string. 5. Basic URL parse _input_ with context object’s url as _url_ and fragment state as _state override_." In between those two steps, a URL record is in an unusable state.
 
 The return value of "failure" in the spec is represented by `null`. That is, functions like `parseURL` and `basicURLParse` can return _either_ a URL record _or_ `null`.
+
+The `parseURLWithValidationErrors` function returns an object with a `url` property and a `validationErrors` property. The `url` property is a URL record or `null`, and the `validationErrors` property is an array of validation error names reported while parsing.
+
+```js
+const result = parseURLWithValidationErrors("https://example.org/%s");
+
+console.log(result.url === null); // false
+console.log(result.validationErrors); // [ "invalid-URL-unit" ]
+```
 
 ### `whatwg-url/webidl2js-wrapper` module
 

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ exports.URL = sharedGlobalObject.URL;
 exports.URLSearchParams = sharedGlobalObject.URLSearchParams;
 
 exports.parseURL = urlStateMachine.parseURL;
+exports.parseURLWithValidationErrors = urlStateMachine.parseURLWithValidationErrors;
 exports.basicURLParse = urlStateMachine.basicURLParse;
 exports.serializeURL = urlStateMachine.serializeURL;
 exports.serializePath = urlStateMachine.serializePath;

--- a/lib/infra.js
+++ b/lib/infra.js
@@ -18,9 +18,14 @@ function isASCIIHex(c) {
   return isASCIIDigit(c) || (c >= 0x41 && c <= 0x46) || (c >= 0x61 && c <= 0x66);
 }
 
+function isNoncharacter(c) {
+  return (c >= 0xFDD0 && c <= 0xFDEF) || (c & 0xFFFE) === 0xFFFE;
+}
+
 module.exports = {
   isASCIIDigit,
   isASCIIAlpha,
   isASCIIAlphanumeric,
-  isASCIIHex
+  isASCIIHex,
+  isNoncharacter
 };

--- a/lib/url-state-machine.js
+++ b/lib/url-state-machine.js
@@ -51,6 +51,40 @@ function isWindowsDriveLetterString(string) {
   return string.length === 2 && infra.isASCIIAlpha(string.codePointAt(0)) && (string[1] === ":" || string[1] === "|");
 }
 
+const urlCodePoints = new Set([
+  p("!"), p("$"), p("&"), p("'"), p("("), p(")"), p("*"), p("+"), p(","), p("-"), p("."), p("/"),
+  p(":"), p(";"), p("="), p("?"), p("@"), p("_"), p("~")
+]);
+
+function isURLCodePoint(c) {
+  return infra.isASCIIAlphanumeric(c) ||
+    urlCodePoints.has(c) ||
+    (c >= 0xA0 && c <= 0x10FFFD && (c < 0xD800 || c > 0xDFFF) && !infra.isNoncharacter(c));
+}
+
+function isInvalidURLCodePoint(c) {
+  return !isURLCodePoint(c) && c !== p("%");
+}
+
+function isInvalidPercentEncoding(input, pointer) {
+  return input[pointer] === p("%") &&
+    (!infra.isASCIIHex(input[pointer + 1]) || !infra.isASCIIHex(input[pointer + 2]));
+}
+
+function validateURLUnits(input, validationErrors = null) {
+  if (validationErrors === null) {
+    return;
+  }
+
+  const codePoints = Array.from(input, c => c.codePointAt(0));
+  if (codePoints.some(isInvalidURLCodePoint)) {
+    validationErrors.push("invalid-URL-unit");
+  }
+  if (codePoints.some((_, i) => isInvalidPercentEncoding(codePoints, i))) {
+    validationErrors.push("invalid-URL-unit");
+  }
+}
+
 function isNormalizedWindowsDriveLetterString(string) {
   return string.length === 2 && infra.isASCIIAlpha(string.codePointAt(0)) && string[1] === ":";
 }
@@ -83,22 +117,26 @@ function defaultPort(scheme) {
   return specialSchemes[scheme];
 }
 
-function parseIPv4Number(input) {
+function parseIPv4Number(input, validationErrors = null) {
   if (input === "") {
     return failure;
   }
 
+  let validationErrorSeen = false;
   let R = 10;
 
   if (input.length >= 2 && input.charAt(0) === "0" && input.charAt(1).toLowerCase() === "x") {
+    validationErrorSeen = true;
     input = input.substring(2);
     R = 16;
   } else if (input.length >= 2 && input.charAt(0) === "0") {
+    validationErrorSeen = true;
     input = input.substring(1);
     R = 8;
   }
 
   if (input === "") {
+    validationErrors?.push("IPv4-non-decimal-part");
     return 0;
   }
 
@@ -114,31 +152,41 @@ function parseIPv4Number(input) {
     return failure;
   }
 
+  if (validationErrorSeen) {
+    validationErrors?.push("IPv4-non-decimal-part");
+  }
+
   return parseInt(input, R);
 }
 
-function parseIPv4(input) {
+function parseIPv4(input, validationErrors = null) {
   const parts = input.split(".");
   if (parts[parts.length - 1] === "") {
+    validationErrors?.push("IPv4-empty-part");
     if (parts.length > 1) {
       parts.pop();
     }
   }
 
   if (parts.length > 4) {
+    validationErrors?.push("IPv4-too-many-parts");
     return failure;
   }
 
   const numbers = [];
   for (const part of parts) {
-    const n = parseIPv4Number(part);
+    const n = parseIPv4Number(part, validationErrors);
     if (n === failure) {
+      validationErrors?.push("IPv4-non-numeric-part");
       return failure;
     }
 
     numbers.push(n);
   }
 
+  if (validationErrors !== null && numbers.some(n => n > 255)) {
+    validationErrors.push("IPv4-out-of-range-part");
+  }
   for (let i = 0; i < numbers.length - 1; ++i) {
     if (numbers[i] > 255) {
       return failure;
@@ -174,7 +222,7 @@ function serializeIPv4(address) {
   return output;
 }
 
-function parseIPv6(input) {
+function parseIPv6(input, validationErrors = null) {
   const address = [0, 0, 0, 0, 0, 0, 0, 0];
   let pieceIndex = 0;
   let compress = null;
@@ -184,6 +232,7 @@ function parseIPv6(input) {
 
   if (input[pointer] === p(":")) {
     if (input[pointer + 1] !== p(":")) {
+      validationErrors?.push("IPv6-invalid-compression");
       return failure;
     }
 
@@ -194,11 +243,13 @@ function parseIPv6(input) {
 
   while (pointer < input.length) {
     if (pieceIndex === 8) {
+      validationErrors?.push("IPv6-too-many-pieces");
       return failure;
     }
 
     if (input[pointer] === p(":")) {
       if (compress !== null) {
+        validationErrors?.push("IPv6-multiple-compression");
         return failure;
       }
       ++pointer;
@@ -218,12 +269,14 @@ function parseIPv6(input) {
 
     if (input[pointer] === p(".")) {
       if (length === 0) {
+        validationErrors?.push("IPv4-in-IPv6-invalid-code-point");
         return failure;
       }
 
       pointer -= length;
 
       if (pieceIndex > 6) {
+        validationErrors?.push("IPv4-in-IPv6-too-many-pieces");
         return failure;
       }
 
@@ -236,11 +289,13 @@ function parseIPv6(input) {
           if (input[pointer] === p(".") && numbersSeen < 4) {
             ++pointer;
           } else {
+            validationErrors?.push("IPv4-in-IPv6-invalid-code-point");
             return failure;
           }
         }
 
         if (!infra.isASCIIDigit(input[pointer])) {
+          validationErrors?.push("IPv4-in-IPv6-invalid-code-point");
           return failure;
         }
 
@@ -249,11 +304,13 @@ function parseIPv6(input) {
           if (ipv4Piece === null) {
             ipv4Piece = number;
           } else if (ipv4Piece === 0) {
+            validationErrors?.push("IPv4-in-IPv6-invalid-code-point");
             return failure;
           } else {
             ipv4Piece = ipv4Piece * 10 + number;
           }
           if (ipv4Piece > 255) {
+            validationErrors?.push("IPv4-in-IPv6-out-of-range-part");
             return failure;
           }
           ++pointer;
@@ -269,6 +326,7 @@ function parseIPv6(input) {
       }
 
       if (numbersSeen !== 4) {
+        validationErrors?.push("IPv4-in-IPv6-too-few-parts");
         return failure;
       }
 
@@ -276,9 +334,11 @@ function parseIPv6(input) {
     } else if (input[pointer] === p(":")) {
       ++pointer;
       if (input[pointer] === undefined) {
+        validationErrors?.push("IPv6-invalid-code-point");
         return failure;
       }
     } else if (input[pointer] !== undefined) {
+      validationErrors?.push("IPv6-invalid-code-point");
       return failure;
     }
 
@@ -297,6 +357,7 @@ function parseIPv6(input) {
       --swaps;
     }
   } else if (compress === null && pieceIndex !== 8) {
+    validationErrors?.push("IPv6-too-few-pieces");
     return failure;
   }
 
@@ -332,27 +393,28 @@ function serializeIPv6(address) {
   return output;
 }
 
-function parseHost(input, isOpaque = false) {
+function parseHost(input, validationErrors = null, isOpaque = false) {
   if (input[0] === "[") {
     if (input[input.length - 1] !== "]") {
+      validationErrors?.push("IPv6-unclosed");
       return failure;
     }
 
-    return parseIPv6(input.substring(1, input.length - 1));
+    return parseIPv6(input.substring(1, input.length - 1), validationErrors);
   }
 
   if (isOpaque) {
-    return parseOpaqueHost(input);
+    return parseOpaqueHost(input, validationErrors);
   }
 
   const domain = utf8DecodeWithoutBOM(percentDecodeString(input));
-  const asciiDomain = domainParser(domain);
+  const asciiDomain = domainParser(domain, validationErrors);
   if (asciiDomain === failure) {
     return failure;
   }
 
   if (endsInANumber(asciiDomain)) {
-    return parseIPv4(asciiDomain);
+    return parseIPv4(asciiDomain, validationErrors);
   }
 
   return asciiDomain;
@@ -368,21 +430,24 @@ function endsInANumber(input) {
   }
 
   const last = parts[parts.length - 1];
-  if (parseIPv4Number(last) !== failure) {
+  if (/^[0-9]+$/u.test(last)) {
     return true;
   }
 
-  if (/^[0-9]+$/u.test(last)) {
+  if (parseIPv4Number(last) !== failure) {
     return true;
   }
 
   return false;
 }
 
-function parseOpaqueHost(input) {
+function parseOpaqueHost(input, validationErrors) {
   if (containsForbiddenHostCodePoint(input)) {
+    validationErrors?.push("host-invalid-code-point");
     return failure;
   }
+
+  validateURLUnits(input, validationErrors);
 
   return utf8PercentEncodeString(input, isC0ControlPercentEncode);
 }
@@ -430,18 +495,31 @@ function serializeHost(host) {
   return host;
 }
 
-function domainParser(domain, beStrict = false) {
+const strictDomainToASCIIOptions = {
+  checkHyphens: true,
+  checkBidi: true,
+  checkJoiners: true,
+  useSTD3ASCIIRules: true,
+  transitionalProcessing: false,
+  verifyDNSLength: true,
+  ignoreInvalidPunycode: false
+};
+
+const domainToASCIIOptions = {
+  checkHyphens: false,
+  checkBidi: true,
+  checkJoiners: true,
+  useSTD3ASCIIRules: false,
+  transitionalProcessing: false,
+  verifyDNSLength: false,
+  ignoreInvalidPunycode: false
+};
+
+function domainParser(domain, validationErrors = null, beStrict = false) {
   if (beStrict) {
-    const result = tr46.toASCII(domain, {
-      checkHyphens: true,
-      checkBidi: true,
-      checkJoiners: true,
-      useSTD3ASCIIRules: true,
-      transitionalProcessing: false,
-      verifyDNSLength: true,
-      ignoreInvalidPunycode: false
-    });
+    const result = tr46.toASCII(domain, strictDomainToASCIIOptions);
     if (result === null) {
+      validationErrors?.push("domain-to-ASCII");
       return failure;
     }
 
@@ -450,42 +528,25 @@ function domainParser(domain, beStrict = false) {
 
   let result;
   if (isASCIIString(domain)) {
-    // The `domain parser` algorithm runs Unicode ToASCII here only to generate a `domain-to-ASCII` validation error,
-    // and we do not surface validation errors yet. If we ever support them
-    // (https://github.com/jsdom/whatwg-url/issues/156), we will need code like the following:
-    //
-    // if (tr46.toASCII(domain, {
-    //   checkHyphens: false,
-    //   checkBidi: true,
-    //   checkJoiners: true,
-    //   useSTD3ASCIIRules: false,
-    //   transitionalProcessing: false,
-    //   verifyDNSLength: false,
-    //   ignoreInvalidPunycode: false
-    // }) === null) {
-    //   validationError("domain-to-ASCII");
-    // }
+    if (validationErrors !== null && tr46.toASCII(domain, domainToASCIIOptions) === null) {
+      validationErrors.push("domain-to-ASCII");
+    }
 
     result = domain.toLowerCase();
   } else {
-    result = tr46.toASCII(domain, {
-      checkHyphens: false,
-      checkBidi: true,
-      checkJoiners: true,
-      useSTD3ASCIIRules: false,
-      transitionalProcessing: false,
-      verifyDNSLength: false,
-      ignoreInvalidPunycode: false
-    });
+    result = tr46.toASCII(domain, domainToASCIIOptions);
     if (result === null) {
+      validationErrors?.push("domain-to-ASCII");
       return failure;
     }
   }
 
   if (result === "") {
+    validationErrors?.push("domain-to-ASCII");
     return failure;
   }
   if (containsForbiddenDomainCodePoint(result)) {
+    validationErrors?.push("domain-invalid-code-point");
     return failure;
   }
 
@@ -542,7 +603,7 @@ function isNormalizedWindowsDriveLetter(string) {
   return /^[A-Za-z]:$/u.test(string);
 }
 
-function URLStateMachine(input, base, encoding, url, stateOverride) {
+function URLStateMachine(input, base, encoding, url, stateOverride, validationErrors = null) {
   this.pointer = 0;
   this.input = input;
   this.base = base || null;
@@ -550,7 +611,7 @@ function URLStateMachine(input, base, encoding, url, stateOverride) {
   this.stateOverride = stateOverride;
   this.url = url;
   this.failure = false;
-  this.parseError = false;
+  this.validationErrors = validationErrors;
 
   if (!this.url) {
     this.url = {
@@ -566,14 +627,14 @@ function URLStateMachine(input, base, encoding, url, stateOverride) {
 
     const res = trimControlChars(this.input);
     if (res !== this.input) {
-      this.parseError = true;
+      this.validationErrors?.push("invalid-URL-unit");
     }
     this.input = res;
   }
 
   const res = trimTabAndNewline(this.input);
   if (res !== this.input) {
-    this.parseError = true;
+    this.validationErrors?.push("invalid-URL-unit");
   }
   this.input = res;
 
@@ -601,6 +662,19 @@ function URLStateMachine(input, base, encoding, url, stateOverride) {
   }
 }
 
+URLStateMachine.prototype.validateURLUnit = function (c) {
+  if (this.validationErrors === null) {
+    return;
+  }
+
+  if (isInvalidURLCodePoint(c)) {
+    this.validationErrors.push("invalid-URL-unit");
+  }
+  if (isInvalidPercentEncoding(this.input, this.pointer)) {
+    this.validationErrors.push("invalid-URL-unit");
+  }
+};
+
 URLStateMachine.prototype["parse scheme start"] = function parseSchemeStart(c, cStr) {
   if (infra.isASCIIAlpha(c)) {
     this.buffer += cStr.toLowerCase();
@@ -609,7 +683,6 @@ URLStateMachine.prototype["parse scheme start"] = function parseSchemeStart(c, c
     this.state = "no scheme";
     --this.pointer;
   } else {
-    this.parseError = true;
     return failure;
   }
 
@@ -647,7 +720,7 @@ URLStateMachine.prototype["parse scheme"] = function parseScheme(c, cStr) {
     this.buffer = "";
     if (this.url.scheme === "file") {
       if (this.input[this.pointer + 1] !== p("/") || this.input[this.pointer + 2] !== p("/")) {
-        this.parseError = true;
+        this.validationErrors?.push("special-scheme-missing-following-solidus");
       }
       this.state = "file";
     } else if (isSpecial(this.url) && this.base !== null && this.base.scheme === this.url.scheme) {
@@ -666,7 +739,6 @@ URLStateMachine.prototype["parse scheme"] = function parseScheme(c, cStr) {
     this.state = "no scheme";
     this.pointer = -1;
   } else {
-    this.parseError = true;
     return failure;
   }
 
@@ -675,6 +747,7 @@ URLStateMachine.prototype["parse scheme"] = function parseScheme(c, cStr) {
 
 URLStateMachine.prototype["parse no scheme"] = function parseNoScheme(c) {
   if (this.base === null || (hasAnOpaquePath(this.base) && c !== p("#"))) {
+    this.validationErrors?.push("missing-scheme-non-relative-URL");
     return failure;
   } else if (hasAnOpaquePath(this.base) && c === p("#")) {
     this.url.scheme = this.base.scheme;
@@ -698,7 +771,7 @@ URLStateMachine.prototype["parse special relative or authority"] = function pars
     this.state = "special authority ignore slashes";
     ++this.pointer;
   } else {
-    this.parseError = true;
+    this.validationErrors?.push("special-scheme-missing-following-solidus");
     this.state = "relative";
     --this.pointer;
   }
@@ -722,7 +795,7 @@ URLStateMachine.prototype["parse relative"] = function parseRelative(c) {
   if (c === p("/")) {
     this.state = "relative slash";
   } else if (isSpecial(this.url) && c === p("\\")) {
-    this.parseError = true;
+    this.validationErrors?.push("invalid-reverse-solidus");
     this.state = "relative slash";
   } else {
     this.url.username = this.base.username;
@@ -751,7 +824,7 @@ URLStateMachine.prototype["parse relative"] = function parseRelative(c) {
 URLStateMachine.prototype["parse relative slash"] = function parseRelativeSlash(c) {
   if (isSpecial(this.url) && (c === p("/") || c === p("\\"))) {
     if (c === p("\\")) {
-      this.parseError = true;
+      this.validationErrors?.push("invalid-reverse-solidus");
     }
     this.state = "special authority ignore slashes";
   } else if (c === p("/")) {
@@ -773,7 +846,7 @@ URLStateMachine.prototype["parse special authority slashes"] = function parseSpe
     this.state = "special authority ignore slashes";
     ++this.pointer;
   } else {
-    this.parseError = true;
+    this.validationErrors?.push("special-scheme-missing-following-solidus");
     this.state = "special authority ignore slashes";
     --this.pointer;
   }
@@ -786,7 +859,7 @@ URLStateMachine.prototype["parse special authority ignore slashes"] = function p
     this.state = "authority";
     --this.pointer;
   } else {
-    this.parseError = true;
+    this.validationErrors?.push("special-scheme-missing-following-solidus");
   }
 
   return true;
@@ -794,7 +867,7 @@ URLStateMachine.prototype["parse special authority ignore slashes"] = function p
 
 URLStateMachine.prototype["parse authority"] = function parseAuthority(c, cStr) {
   if (c === p("@")) {
-    this.parseError = true;
+    this.validationErrors?.push("invalid-credentials");
     if (this.atSignSeen) {
       this.buffer = `%40${this.buffer}`;
     }
@@ -820,7 +893,7 @@ URLStateMachine.prototype["parse authority"] = function parseAuthority(c, cStr) 
   } else if (isNaN(c) || c === p("/") || c === p("?") || c === p("#") ||
              (isSpecial(this.url) && c === p("\\"))) {
     if (this.atSignSeen && this.buffer === "") {
-      this.parseError = true;
+      this.validationErrors?.push("host-missing");
       return failure;
     }
     this.pointer -= countSymbols(this.buffer) + 1;
@@ -840,7 +913,7 @@ URLStateMachine.prototype["parse host"] = function parseHostName(c, cStr) {
     this.state = "file host";
   } else if (c === p(":") && !this.insideBrackets) {
     if (this.buffer === "") {
-      this.parseError = true;
+      this.validationErrors?.push("host-missing");
       return failure;
     }
 
@@ -848,7 +921,7 @@ URLStateMachine.prototype["parse host"] = function parseHostName(c, cStr) {
       return failure;
     }
 
-    const host = parseHost(this.buffer, isNotSpecial(this.url));
+    const host = parseHost(this.buffer, this.validationErrors, isNotSpecial(this.url));
     if (host === failure) {
       return failure;
     }
@@ -860,15 +933,14 @@ URLStateMachine.prototype["parse host"] = function parseHostName(c, cStr) {
              (isSpecial(this.url) && c === p("\\"))) {
     --this.pointer;
     if (isSpecial(this.url) && this.buffer === "") {
-      this.parseError = true;
+      this.validationErrors?.push("host-missing");
       return failure;
     } else if (this.stateOverride && this.buffer === "" &&
                (includesCredentials(this.url) || this.url.port !== null)) {
-      this.parseError = true;
       return failure;
     }
 
-    const host = parseHost(this.buffer, isNotSpecial(this.url));
+    const host = parseHost(this.buffer, this.validationErrors, isNotSpecial(this.url));
     if (host === failure) {
       return failure;
     }
@@ -900,7 +972,7 @@ URLStateMachine.prototype["parse port"] = function parsePort(c, cStr) {
     if (this.buffer !== "") {
       const port = parseInt(this.buffer, 10);
       if (port > 2 ** 16 - 1) {
-        this.parseError = true;
+        this.validationErrors?.push("port-out-of-range");
         return failure;
       }
       this.url.port = port === defaultPort(this.url.scheme) ? null : port;
@@ -915,7 +987,7 @@ URLStateMachine.prototype["parse port"] = function parsePort(c, cStr) {
     this.state = "path start";
     --this.pointer;
   } else {
-    this.parseError = true;
+    this.validationErrors?.push("port-invalid");
     return failure;
   }
 
@@ -937,7 +1009,7 @@ URLStateMachine.prototype["parse file"] = function parseFile(c) {
 
   if (c === p("/") || c === p("\\")) {
     if (c === p("\\")) {
-      this.parseError = true;
+      this.validationErrors?.push("invalid-reverse-solidus");
     }
     this.state = "file slash";
   } else if (this.base !== null && this.base.scheme === "file") {
@@ -955,7 +1027,7 @@ URLStateMachine.prototype["parse file"] = function parseFile(c) {
       if (!startsWithWindowsDriveLetter(this.input, this.pointer)) {
         shortenPath(this.url);
       } else {
-        this.parseError = true;
+        this.validationErrors?.push("file-invalid-Windows-drive-letter");
         this.url.path = [];
       }
 
@@ -973,7 +1045,7 @@ URLStateMachine.prototype["parse file"] = function parseFile(c) {
 URLStateMachine.prototype["parse file slash"] = function parseFileSlash(c) {
   if (c === p("/") || c === p("\\")) {
     if (c === p("\\")) {
-      this.parseError = true;
+      this.validationErrors?.push("invalid-reverse-solidus");
     }
     this.state = "file host";
   } else {
@@ -995,7 +1067,7 @@ URLStateMachine.prototype["parse file host"] = function parseFileHost(c, cStr) {
   if (isNaN(c) || c === p("/") || c === p("\\") || c === p("?") || c === p("#")) {
     --this.pointer;
     if (!this.stateOverride && isWindowsDriveLetterString(this.buffer)) {
-      this.parseError = true;
+      this.validationErrors?.push("file-invalid-Windows-drive-letter-host");
       this.state = "path";
     } else if (this.buffer === "") {
       this.url.host = "";
@@ -1004,7 +1076,7 @@ URLStateMachine.prototype["parse file host"] = function parseFileHost(c, cStr) {
       }
       this.state = "path start";
     } else {
-      let host = parseHost(this.buffer, isNotSpecial(this.url));
+      let host = parseHost(this.buffer, this.validationErrors, isNotSpecial(this.url));
       if (host === failure) {
         return failure;
       }
@@ -1030,7 +1102,7 @@ URLStateMachine.prototype["parse file host"] = function parseFileHost(c, cStr) {
 URLStateMachine.prototype["parse path start"] = function parsePathStart(c) {
   if (isSpecial(this.url)) {
     if (c === p("\\")) {
-      this.parseError = true;
+      this.validationErrors?.push("invalid-reverse-solidus");
     }
     this.state = "path";
 
@@ -1059,7 +1131,7 @@ URLStateMachine.prototype["parse path"] = function parsePath(c) {
   if (isNaN(c) || c === p("/") || (isSpecial(this.url) && c === p("\\")) ||
       (!this.stateOverride && (c === p("?") || c === p("#")))) {
     if (isSpecial(this.url) && c === p("\\")) {
-      this.parseError = true;
+      this.validationErrors?.push("invalid-reverse-solidus");
     }
 
     if (isDoubleDot(this.buffer)) {
@@ -1086,13 +1158,7 @@ URLStateMachine.prototype["parse path"] = function parsePath(c) {
       this.state = "fragment";
     }
   } else {
-    // TODO: If c is not a URL code point and not "%", parse error.
-
-    if (c === p("%") &&
-      (!infra.isASCIIHex(this.input[this.pointer + 1]) ||
-        !infra.isASCIIHex(this.input[this.pointer + 2]))) {
-      this.parseError = true;
-    }
+    this.validateURLUnit(c);
 
     this.buffer += utf8PercentEncodeCodePoint(c, isPathPercentEncode);
   }
@@ -1114,21 +1180,10 @@ URLStateMachine.prototype["parse opaque path"] = function parseOpaquePath(c) {
     } else {
       this.url.path += " ";
     }
-  } else {
-    // TODO: Add: not a URL code point
-    if (!isNaN(c) && c !== p("%")) {
-      this.parseError = true;
-    }
+  } else if (!isNaN(c)) {
+    this.validateURLUnit(c);
 
-    if (c === p("%") &&
-        (!infra.isASCIIHex(this.input[this.pointer + 1]) ||
-         !infra.isASCIIHex(this.input[this.pointer + 2]))) {
-      this.parseError = true;
-    }
-
-    if (!isNaN(c)) {
-      this.url.path += utf8PercentEncodeCodePoint(c, isC0ControlPercentEncode);
-    }
+    this.url.path += utf8PercentEncodeCodePoint(c, isC0ControlPercentEncode);
   }
 
   return true;
@@ -1154,13 +1209,7 @@ URLStateMachine.prototype["parse query"] = function parseQuery(c, cStr) {
       this.state = "fragment";
     }
   } else if (!isNaN(c)) {
-    // TODO: If c is not a URL code point and not "%", parse error.
-
-    if (c === p("%") &&
-      (!infra.isASCIIHex(this.input[this.pointer + 1]) ||
-        !infra.isASCIIHex(this.input[this.pointer + 2]))) {
-      this.parseError = true;
-    }
+    this.validateURLUnit(c);
 
     this.buffer += cStr;
   }
@@ -1170,12 +1219,7 @@ URLStateMachine.prototype["parse query"] = function parseQuery(c, cStr) {
 
 URLStateMachine.prototype["parse fragment"] = function parseFragment(c) {
   if (!isNaN(c)) {
-    // TODO: If c is not a URL code point and not "%", parse error.
-    if (c === p("%") &&
-      (!infra.isASCIIHex(this.input[this.pointer + 1]) ||
-        !infra.isASCIIHex(this.input[this.pointer + 2]))) {
-      this.parseError = true;
-    }
+    this.validateURLUnit(c);
 
     this.url.fragment += utf8PercentEncodeCodePoint(c, isFragmentPercentEncode);
   }
@@ -1284,17 +1328,24 @@ module.exports.serializeURLOrigin = function (url) {
   }
 };
 
-module.exports.basicURLParse = function (input, options) {
-  if (options === undefined) {
-    options = {};
-  }
-
-  const usm = new URLStateMachine(input, options.baseURL, options.encoding, options.url, options.stateOverride);
+function basicURLParse(input, options = {}, validationErrors = null) {
+  const usm = new URLStateMachine(
+    input,
+    options.baseURL,
+    options.encoding,
+    options.url,
+    options.stateOverride,
+    validationErrors
+  );
   if (usm.failure) {
     return null;
   }
 
   return usm.url;
+}
+
+module.exports.basicURLParse = function (input, options = {}) {
+  return basicURLParse(input, options);
 };
 
 module.exports.setTheUsername = function (url, username) {
@@ -1315,11 +1366,22 @@ module.exports.serializeInteger = function (integer) {
   return String(integer);
 };
 
-module.exports.parseURL = function (input, options) {
-  if (options === undefined) {
-    options = {};
-  }
+module.exports.parseURL = function (input, options = {}) {
+  // We don't handle blobs, so this just delegates:
+  return module.exports.basicURLParse(input, {
+    baseURL: options.baseURL,
+    encoding: options.encoding
+  });
+};
+
+module.exports.parseURLWithValidationErrors = function (input, options = {}) {
+  const validationErrors = [];
 
   // We don't handle blobs, so this just delegates:
-  return module.exports.basicURLParse(input, { baseURL: options.baseURL, encoding: options.encoding });
+  const url = basicURLParse(input, {
+    baseURL: options.baseURL,
+    encoding: options.encoding
+  }, validationErrors);
+
+  return { url, validationErrors };
 };

--- a/live-viewer/index.html
+++ b/live-viewer/index.html
@@ -57,25 +57,31 @@ serves as a good comparison versus the standard itself.
 
 <h2>jsdom/whatwg-url's components</h2>
 
-<table class="output" id="jsdom-output">
-  <tr class="href"><th>href</th><td></td></tr>
-  <tr class="protocol"><th>protocol</th><td></td></tr>
-  <tr class="username"><th>username</th><td></td></tr>
-  <tr class="password"><th>password</th><td></td></tr>
-  <tr class="port"><th>port</th><td></td></tr>
-  <tr class="hostname"><th>hostname</th><td></td></tr>
-  <tr class="pathname"><th>pathname</th><td></td></tr>
-  <tr class="search"><th>search</th><td></td></tr>
-  <tr class="hash"><th>hash</th><td></td></tr>
-  <tr class="origin"><th>origin</th><td></td></tr>
-</table>
+<div class="jsdom-results">
+  <table class="output" id="jsdom-output">
+    <tr class="href"><th>href</th><td></td></tr>
+    <tr class="protocol"><th>protocol</th><td></td></tr>
+    <tr class="username"><th>username</th><td></td></tr>
+    <tr class="password"><th>password</th><td></td></tr>
+    <tr class="port"><th>port</th><td></td></tr>
+    <tr class="hostname"><th>hostname</th><td></td></tr>
+    <tr class="pathname"><th>pathname</th><td></td></tr>
+    <tr class="search"><th>search</th><td></td></tr>
+    <tr class="hash"><th>hash</th><td></td></tr>
+    <tr class="origin"><th>origin</th><td></td></tr>
+  </table>
 
-<p class="output error" id="jsdom-error"></p>
+  <section class="output validation-errors" id="jsdom-validation-errors" aria-live="polite">
+    <p class="parse-error" id="jsdom-error" hidden></p>
+    <h3></h3>
+    <ol></ol>
+  </section>
+</div>
 
 <aside>
   <p>Note: <code>window.whatwgURL</code> is exposed in the browser console if you would like to play around with it there.</p>
 </aside>
 
 <footer>
-  <a href="https://github.com/jsdom/whatwg-url/tree/master/live-viewer">Fork me on GitHub!</a>
+  <a href="https://github.com/jsdom/whatwg-url/tree/main/live-viewer">Fork me on GitHub!</a>
 </footer>

--- a/live-viewer/live-viewer.mjs
+++ b/live-viewer/live-viewer.mjs
@@ -37,10 +37,12 @@ update();
 function update() {
   const browserResult = getBrowserResult();
   const jsdomResult = getJsdomResult();
+  const jsdomValidationResult = getJsdomValidationResult();
   const mismatchedComponents = getMismatchedComponents(browserResult, jsdomResult);
 
   setResult("browser", browserResult, mismatchedComponents);
   setResult("jsdom", jsdomResult, mismatchedComponents);
+  setValidationErrors(jsdomValidationResult, jsdomResult instanceof Error);
   updateFragmentForSharing();
 }
 
@@ -83,6 +85,37 @@ function setComponentElMismatch(componentEl, isMismatched) {
   componentEl.classList.toggle("fail", isMismatched);
 }
 
+function setValidationErrors(result, hasParseError) {
+  const validationErrorsEl = document.querySelector("#jsdom-validation-errors");
+  const headingEl = validationErrorsEl.querySelector("h3");
+  const listEl = validationErrorsEl.querySelector("ol");
+  const { validationErrors } = result;
+
+  validationErrorsEl.parentElement.classList.toggle("has-parse-error", hasParseError);
+  validationErrorsEl.classList.toggle("has-parse-error", hasParseError);
+  validationErrorsEl.classList.toggle("unavailable", result.isUnavailable);
+  validationErrorsEl.classList.toggle("valid", validationErrors.length === 0 && !result.isUnavailable && !hasParseError);
+
+  if (result.isUnavailable) {
+    headingEl.textContent = "Validation unavailable";
+    listEl.replaceChildren();
+    listEl.hidden = true;
+    return;
+  }
+
+  headingEl.textContent = `${validationErrors.length} validation ${validationErrors.length === 1 ? "error" : "errors"}`;
+  listEl.replaceChildren();
+  listEl.hidden = validationErrors.length === 0;
+
+  for (const error of validationErrors) {
+    const item = document.createElement("li");
+    const errorName = document.createElement("code");
+    errorName.textContent = error;
+    item.append(errorName);
+    listEl.append(item);
+  }
+}
+
 function getMismatchedComponents(result1, result2) {
   const mismatched = new Set();
   for (const component of components) {
@@ -107,6 +140,19 @@ function getJsdomResult() {
   } catch (e) {
     return e;
   }
+}
+
+function getJsdomValidationResult() {
+  const baseURL = whatwgURL.parseURL(baseEl.value);
+
+  if (baseURL === null) {
+    return { validationErrors: [], isUnavailable: true };
+  }
+
+  return {
+    validationErrors: whatwgURL.parseURLWithValidationErrors(inputEl.value, { baseURL }).validationErrors,
+    isUnavailable: false
+  };
 }
 
 // We use "url=" in the fragment for backward-compatibility, even though "input=" would be a bit more correct.

--- a/live-viewer/style.css
+++ b/live-viewer/style.css
@@ -1,16 +1,25 @@
+:root {
+  --monospace-font: 'Bitstream Vera Sans Mono', 'Andale Mono', 'Lucida Console', monospace, fixed;
+  --output-width: 95%;
+  --error-color: rgb(220 20 60);
+  --pass-color: rgb(0 128 0);
+  --fail-color: rgb(255 0 0);
+  --unavailable-color: rgb(128 128 128);
+}
+
 * {
   box-sizing: border-box;
 }
 
 body {
-  font-family: Georgia;
+  font-family: Georgia, serif;
   max-width: 70em;
   margin: 12px;
 }
 
 h1, h2, h3, h4, h5, h6 {
   font-style: italic;
-  color: DarkBlue;
+  color: rgb(0 0 139);
   margin-bottom: 0.2em;
 }
 
@@ -38,55 +47,121 @@ footer {
   right: 1em;
 }
 
-form label {
-  display: block;
-  margin-bottom: 6px;
-}
+form {
+  label {
+    display: block;
+    margin-bottom: 6px;
+  }
 
-form input {
-  width: 90%;
-  margin-bottom: 20px;
-  padding: 3px;
+  input {
+    width: 90%;
+    margin-bottom: 20px;
+    padding: 3px;
+  }
 }
 
 .output {
-  background-color: whitesmoke;
-  border: 1px dashed crimson;
-  width: 95%;
+  background-color: rgb(245 245 245);
+  border: 1px dashed var(--error-color);
+  width: var(--output-width);
   padding: 1em;
   margin: 0;
-}
 
-.output.error {
-  color: Crimson;
-}
+  &.error {
+    color: var(--error-color);
+  }
 
-.output th {
-  width: 100px;
-  text-align: right;
-  padding-right: 20px;
-}
+  th {
+    width: 100px;
+    text-align: right;
+    padding-right: 20px;
+  }
 
-.output td {
-  font-family: 'Bitstream Vera Sans Mono', 'Andale Mono', 'Lucida Console', monospace, fixed;
+  td {
+    font-family: var(--monospace-font);
+
+    &.empty-string {
+      font-family: inherit;
+      font-size: smaller;
+      font-style: italic;
+
+      &:not(.fail) {
+        color: rgb(204 204 204);
+      }
+    }
+  }
 }
 
 .pass {
-  color: green;
+  color: var(--pass-color);
 }
 
 .fail {
-  color: red;
+  color: var(--fail-color);
 }
 
-.output td.empty-string {
-  font-family: inherit;
-  font-size: smaller;
-  font-style: italic;
+.jsdom-results {
+  display: grid;
+  gap: 1em;
+  width: var(--output-width);
+
+  > .output {
+    width: 100%;
+  }
+
+  @media (min-width: 58em) {
+    grid-template-columns: minmax(0, 2fr) minmax(16em, 1fr);
+    align-items: stretch;
+  }
 }
 
-.output td.empty-string:not(.fail) {
-  color: #CCC;
+.validation-errors {
+  align-self: start;
+  min-height: 100%;
+
+  h3 {
+    margin-top: 0;
+    font-size: 1.2em;
+  }
+
+  .parse-error {
+    color: var(--error-color);
+  }
+
+  li code {
+    font-family: var(--monospace-font);
+    overflow-wrap: anywhere;
+  }
+
+  &.valid {
+    border-color: var(--pass-color);
+
+    h3 {
+      color: var(--pass-color);
+      font-family: inherit;
+      font-weight: bold;
+    }
+  }
+
+  &.unavailable {
+    border-color: var(--unavailable-color);
+
+    h3 {
+      color: var(--unavailable-color);
+    }
+  }
+
+  &.has-parse-error {
+    border-color: var(--error-color);
+  }
+}
+
+@media (min-width: 58em) {
+  .jsdom-results {
+    &.has-parse-error .validation-errors {
+      grid-column: 1 / -1;
+    }
+  }
 }
 
 summary {
@@ -98,8 +173,9 @@ samp {
 }
 
 aside {
-  border-left: .25rem solid gray;
-}
-aside p {
-  margin-left: .5rem;
+  border-left: .25rem solid var(--unavailable-color);
+
+  p {
+    margin-left: .5rem;
+  }
 }

--- a/test/validation-errors.js
+++ b/test/validation-errors.js
@@ -1,0 +1,219 @@
+"use strict";
+const { describe, test } = require("node:test");
+const assert = require("node:assert");
+
+const { parseURL, parseURLWithValidationErrors } = require("..");
+
+const validationErrorNames = [
+  "domain-to-ASCII",
+  "domain-invalid-code-point",
+  "host-invalid-code-point",
+  "IPv4-empty-part",
+  "IPv4-too-many-parts",
+  "IPv4-non-numeric-part",
+  "IPv4-non-decimal-part",
+  "IPv4-out-of-range-part",
+  "IPv6-unclosed",
+  "IPv6-invalid-compression",
+  "IPv6-too-many-pieces",
+  "IPv6-multiple-compression",
+  "IPv6-invalid-code-point",
+  "IPv6-too-few-pieces",
+  "IPv4-in-IPv6-too-many-pieces",
+  "IPv4-in-IPv6-invalid-code-point",
+  "IPv4-in-IPv6-out-of-range-part",
+  "IPv4-in-IPv6-too-few-parts",
+  "invalid-URL-unit",
+  "special-scheme-missing-following-solidus",
+  "missing-scheme-non-relative-URL",
+  "invalid-reverse-solidus",
+  "invalid-credentials",
+  "host-missing",
+  "port-out-of-range",
+  "port-invalid",
+  "file-invalid-Windows-drive-letter",
+  "file-invalid-Windows-drive-letter-host"
+];
+
+const validationErrorTestCases = [
+  {
+    input: "https://xn--8i7caa/",
+    validationErrors: ["domain-to-ASCII"]
+  },
+  {
+    input: "https://\u200D.example/",
+    validationErrors: ["domain-to-ASCII"],
+    failure: true
+  },
+  {
+    input: "https://exa%23mple.org",
+    validationErrors: ["domain-invalid-code-point"],
+    failure: true
+  },
+  {
+    input: "foo://exa[mple.org",
+    validationErrors: ["host-invalid-code-point"],
+    failure: true
+  },
+  {
+    input: "https://127.0.0.1./",
+    validationErrors: ["IPv4-empty-part"]
+  },
+  {
+    input: "https://1.2.3.4.5/",
+    validationErrors: ["IPv4-too-many-parts"],
+    failure: true
+  },
+  {
+    input: "https://test.42",
+    validationErrors: ["IPv4-non-numeric-part"],
+    failure: true
+  },
+  {
+    input: "https://127.0.0x0.1",
+    validationErrors: ["IPv4-non-decimal-part"]
+  },
+  {
+    input: "https://255.255.4000.1",
+    validationErrors: ["IPv4-out-of-range-part"],
+    failure: true
+  },
+  {
+    input: "https://[::1",
+    validationErrors: ["IPv6-unclosed"],
+    failure: true
+  },
+  {
+    input: "https://[:1]",
+    validationErrors: ["IPv6-invalid-compression"],
+    failure: true
+  },
+  {
+    input: "https://[1:2:3:4:5:6:7:8:9]",
+    validationErrors: ["IPv6-too-many-pieces"],
+    failure: true
+  },
+  {
+    input: "https://[1::1::1]",
+    validationErrors: ["IPv6-multiple-compression"],
+    failure: true
+  },
+  {
+    input: "https://[1:2:3!:4]",
+    validationErrors: ["IPv6-invalid-code-point"],
+    failure: true
+  },
+  {
+    input: "https://[1:2:3]",
+    validationErrors: ["IPv6-too-few-pieces"],
+    failure: true
+  },
+  {
+    input: "https://[1:1:1:1:1:1:1:127.0.0.1]",
+    validationErrors: ["IPv4-in-IPv6-too-many-pieces"],
+    failure: true
+  },
+  {
+    input: "https://[ffff::127.00.0.1]",
+    validationErrors: ["IPv4-in-IPv6-invalid-code-point"],
+    failure: true
+  },
+  {
+    input: "https://[ffff::127.0.0.4000]",
+    validationErrors: ["IPv4-in-IPv6-out-of-range-part"],
+    failure: true
+  },
+  {
+    input: "https://[ffff::127.0.0]",
+    validationErrors: ["IPv4-in-IPv6-too-few-parts"],
+    failure: true
+  },
+  {
+    input: "https://example.org/>",
+    validationErrors: ["invalid-URL-unit"]
+  },
+  {
+    input: "https://example.org/%s",
+    validationErrors: ["invalid-URL-unit"]
+  },
+  {
+    input: "https:example.org",
+    validationErrors: ["special-scheme-missing-following-solidus"]
+  },
+  {
+    input: "example",
+    validationErrors: ["missing-scheme-non-relative-URL"],
+    failure: true
+  },
+  {
+    input: "https://example.org\\",
+    validationErrors: ["invalid-reverse-solidus"]
+  },
+  {
+    input: "https://user@example.org",
+    validationErrors: ["invalid-credentials"]
+  },
+  {
+    input: "https://#fragment",
+    validationErrors: ["host-missing"],
+    failure: true
+  },
+  {
+    input: "https://example.org:70000",
+    validationErrors: ["port-out-of-range"],
+    failure: true
+  },
+  {
+    input: "https://example.org:7z",
+    validationErrors: ["port-invalid"],
+    failure: true
+  },
+  {
+    input: "c|/path/to/file",
+    base: "file:///c:/",
+    validationErrors: ["file-invalid-Windows-drive-letter", "invalid-URL-unit"]
+  },
+  {
+    input: "file://c:",
+    validationErrors: ["file-invalid-Windows-drive-letter-host"]
+  }
+];
+
+describe("validation errors", () => {
+  test("test cases cover every named validation error", () => {
+    const coveredErrors = new Set();
+    for (const { validationErrors } of validationErrorTestCases) {
+      for (const validationError of validationErrors) {
+        coveredErrors.add(validationError);
+      }
+    }
+
+    assert.deepStrictEqual([...coveredErrors].sort(), validationErrorNames.toSorted());
+  });
+
+  for (const testCase of validationErrorTestCases) {
+    test(`${testCase.input} reports ${testCase.validationErrors.join(", ")}`, () => {
+      const options = {};
+      if (testCase.base !== undefined) {
+        options.baseURL = parseURL(testCase.base);
+        assert.notEqual(options.baseURL, null, "The base URL must parse successfully");
+      }
+
+      const { url, validationErrors } = parseURLWithValidationErrors(testCase.input, options);
+
+      assert.deepStrictEqual(validationErrors, testCase.validationErrors);
+      assert.equal(url === null, testCase.failure === true);
+    });
+  }
+
+  test("reports validation errors in order, including repeated error names", () => {
+    const { url, validationErrors } = parseURLWithValidationErrors(" https://user@example.org/%s ");
+
+    assert.notEqual(url, null);
+    assert.deepStrictEqual(validationErrors, [
+      "invalid-URL-unit",
+      "invalid-credentials",
+      "invalid-URL-unit"
+    ]);
+  });
+});


### PR DESCRIPTION
Adds validation error collection to the URL parser and surfaces it through `parseURLWithValidationErrors()` and the live viewer.

Closes #61. Closes #59. Closes #260. Helps with #156, but does not include the grammar-based validator discussed there.