### PR TITLE
Add host to Live URL Viewer

### DIFF
--- a/live-viewer/index.html
+++ b/live-viewer/index.html
@@ -45,6 +45,7 @@ serves as a good comparison versus the standard itself.
   <tr class="protocol"><th>protocol</th><td></td></tr>
   <tr class="username"><th>username</th><td></td></tr>
   <tr class="password"><th>password</th><td></td></tr>
+  <tr class="host"><th>host</th><td></td></tr>
   <tr class="port"><th>port</th><td></td></tr>
   <tr class="hostname"><th>hostname</th><td></td></tr>
   <tr class="pathname"><th>pathname</th><td></td></tr>
@@ -63,6 +64,7 @@ serves as a good comparison versus the standard itself.
     <tr class="protocol"><th>protocol</th><td></td></tr>
     <tr class="username"><th>username</th><td></td></tr>
     <tr class="password"><th>password</th><td></td></tr>
+    <tr class="host"><th>host</th><td></td></tr>
     <tr class="port"><th>port</th><td></td></tr>
     <tr class="hostname"><th>hostname</th><td></td></tr>
     <tr class="pathname"><th>pathname</th><td></td></tr>

--- a/live-viewer/live-viewer.mjs
+++ b/live-viewer/live-viewer.mjs
@@ -15,6 +15,7 @@ const components = [
   "protocol",
   "username",
   "password",
+  "host",
   "port",
   "hostname",
   "pathname",


### PR DESCRIPTION
Adds the `host` row to both Live URL Viewer comparison tables and includes it in mismatch highlighting.