### PR TITLE
Close gaps between URL writing and parser sections

### DIFF
--- a/lib/url-miscellaneous.js
+++ b/lib/url-miscellaneous.js
@@ -19,26 +19,6 @@ const specialSchemes = {
   wss: 443
 };
 
-const strictDomainToASCIIOptions = {
-  checkHyphens: true,
-  checkBidi: true,
-  checkJoiners: true,
-  useSTD3ASCIIRules: true,
-  transitionalProcessing: false,
-  verifyDNSLength: true,
-  ignoreInvalidPunycode: false
-};
-
-const domainToASCIIOptions = {
-  checkHyphens: false,
-  checkBidi: true,
-  checkJoiners: true,
-  useSTD3ASCIIRules: false,
-  transitionalProcessing: false,
-  verifyDNSLength: false,
-  ignoreInvalidPunycode: false
-};
-
 const urlCodePoints = new Set([
   p("!"), p("$"), p("&"), p("'"), p("("), p(")"), p("*"), p("+"), p(","), p("-"), p("."), p("/"),
   p(":"), p(";"), p("="), p("?"), p("@"), p("_"), p("~")
@@ -66,6 +46,10 @@ function isPercentEncodedByteAt(input, index) {
     infra.isASCIIHex(input.charCodeAt(index + 2));
 }
 
+function containsPercentEncodedByte(input) {
+  return /%[0-9A-Fa-f]{2}/u.test(input);
+}
+
 function containsForbiddenHostCodePoint(string) {
   return [...string].some(c => forbiddenHostCodePoints.has(c.codePointAt(0)));
 }
@@ -77,38 +61,52 @@ function containsForbiddenDomainCodePoint(string) {
   });
 }
 
+function domainParserToASCII(domain, beStrict) {
+  return tr46.toASCII(domain, {
+    checkHyphens: beStrict,
+    checkBidi: true,
+    checkJoiners: true,
+    useSTD3ASCIIRules: beStrict,
+    transitionalProcessing: false,
+    verifyDNSLength: beStrict,
+    ignoreInvalidPunycode: false
+  });
+}
+
 function domainParser(domain, validationErrors = null, beStrict = false) {
-  if (beStrict) {
-    const result = tr46.toASCII(domain, strictDomainToASCIIOptions);
-    if (result === null) {
+  // A domain-to-ASCII validation error is reported whenever the strict Unicode ToASCII (CheckHyphens,
+  // UseSTD3ASCIIRules, and VerifyDnsLength all true) fails, even when the relaxed parameters used
+  // for non-strict parsing succeed. This step does not itself fail the algorithm.
+  //
+  // Spec divergence (performance): the URL Standard runs this strict pass unconditionally, but when
+  // beStrict is false its only effect is that validation error, so we skip it when we are neither
+  // being strict nor collecting validation errors.
+  if (beStrict || validationErrors) {
+    const strictResult = domainParserToASCII(domain, true);
+    if (strictResult === null) {
       validationErrors?.push("domain-to-ASCII");
-      return failure;
     }
 
-    return result;
+    if (beStrict) {
+      return strictResult === null ? failure : strictResult;
+    }
   }
 
   let result;
   if (infra.isASCIIString(domain)) {
-    if (validationErrors !== null && tr46.toASCII(domain, domainToASCIIOptions) === null) {
-      validationErrors.push("domain-to-ASCII");
-    }
-
+    // For web compatibility an ASCII domain is returned lowercased regardless of ToASCII's outcome.
     result = domain.toLowerCase();
   } else {
-    result = tr46.toASCII(domain, domainToASCIIOptions);
+    result = domainParserToASCII(domain, false);
     if (result === null) {
-      validationErrors?.push("domain-to-ASCII");
       return failure;
     }
   }
 
   if (result === "") {
-    validationErrors?.push("domain-to-ASCII");
     return failure;
   }
   if (containsForbiddenDomainCodePoint(result)) {
-    validationErrors?.push("domain-invalid-code-point");
     return failure;
   }
 
@@ -141,6 +139,7 @@ function isNormalizedWindowsDriveLetterString(string) {
 
 module.exports = {
   containsForbiddenHostCodePoint,
+  containsPercentEncodedByte,
   defaultPort,
   domainParser,
   failure,

--- a/lib/url-state-machine.js
+++ b/lib/url-state-machine.js
@@ -6,6 +6,7 @@ const infra = require("./infra");
 const { utf8DecodeWithoutBOM } = require("./encoding");
 const {
   containsForbiddenHostCodePoint,
+  containsPercentEncodedByte,
   defaultPort,
   domainParser,
   failure,
@@ -354,6 +355,10 @@ function parseHost(input, validationErrors = null, isOpaque = false) {
 
   if (isOpaque) {
     return parseOpaqueHost(input, validationErrors);
+  }
+
+  if (validationErrors && containsPercentEncodedByte(input)) {
+    validationErrors.push("domain-percent-encoded");
   }
 
   const domain = utf8DecodeWithoutBOM(percentDecodeString(input));
@@ -1061,6 +1066,8 @@ URLStateMachine.prototype["parse opaque path"] = function parseOpaquePath(c) {
     this.url.fragment = "";
     this.state = "fragment";
   } else if (c === p(" ")) {
+    this.validationErrors?.push("invalid-URL-unit");
+
     const remaining = this.input[this.pointer + 1];
     if (remaining === p("?") || remaining === p("#")) {
       this.url.path += "%20";

--- a/lib/url-string-validator.js
+++ b/lib/url-string-validator.js
@@ -12,6 +12,7 @@ const {
 } = require("./url-miscellaneous");
 
 const pathSegmentExcludedCodePoints = new Set([p("/"), p("?")]);
+const opaquePathExcludedCodePoints = new Set([p("?")]);
 
 function splitOffFragment(input) {
   const fragmentStart = input.indexOf("#");
@@ -74,7 +75,13 @@ function isValidAbsoluteURLString(input) {
     return isValidSchemeRelativeFileURLString(afterScheme);
   }
 
-  return isValidRelativeURLStringForScheme(afterScheme, scheme);
+  // A non-special scheme is followed by one of: a scheme-relative-URL string, a path-absolute-URL
+  // string, or an opaque-path-URL string. They are disjoint by leading code point ("//", "/", and
+  // neither, respectively), so an authority form like "foo://user@host" can only match the
+  // scheme-relative-URL string and is therefore still rejected for expressing credentials.
+  return isValidSchemeRelativeURLString(afterScheme) ||
+    isValidPathAbsoluteURLString(afterScheme) ||
+    isValidOpaquePathURLString(afterScheme);
 }
 
 function isValidRelativeURLWithFragmentString(input, baseURL) {
@@ -329,6 +336,10 @@ function isValidURLPathSegmentString(input) {
 
 function isValidPathRelativeSchemeLessURLString(input) {
   return isValidPathRelativeURLString(input) && !/^[A-Za-z][A-Za-z0-9+.-]*:/u.test(input);
+}
+
+function isValidOpaquePathURLString(input) {
+  return (input === "" || input[0] !== "/") && isValidURLUnits(input, opaquePathExcludedCodePoints);
 }
 
 function isValidURLQueryString(input) {

--- a/test/url-string-validator.js
+++ b/test/url-string-validator.js
@@ -25,7 +25,9 @@ describe("isValidURLString", () => {
     "hello:world",
     "foo://",
     "foo:///path",
-    "foo://example:65535/path?query#fragment"
+    "foo://example:65535/path?query#fragment",
+    "foo:a:b",
+    "urn:isbn:0451450523"
   ];
 
   for (const input of validAbsoluteURLStrings) {
@@ -127,10 +129,12 @@ describe("isValidURLString", () => {
   });
 
   test("URL-writing validity is separate from parser validation errors", () => {
+    // These parse cleanly (no validation errors) yet are not valid URL strings: a path-absolute-URL
+    // string cannot start with "//", but the parser happily produces an empty leading path segment.
     const grammarInvalidParserValid = [
-      "file://loc%61lhost/",
-      "https://%30/",
-      "https://example.org//"
+      "https://example.org//",
+      "https://example.org//p",
+      "foo://example.org//"
     ];
 
     for (const input of grammarInvalidParserValid) {
@@ -158,28 +162,52 @@ describe("isValidURLString", () => {
     }
   });
 
-  test("documents current behavior for whatwg/url#905 examples", () => {
-    // https://github.com/whatwg/url/pull/905 discusses changing these results. Until that PR
-    // lands, assert the current behavior so any later update is intentional.
-    const cases = [
-      "https://exam%70le.org",
-      "https://_dmarc.example.com",
-      "foo:bar baz",
-      "foo:a:b"
+  test("relative-URL strings can be valid yet unresolvable against a cannot-be-a-base base", () => {
+    // The relative-URL string grammar switches only on the base URL's scheme, so these are valid
+    // URL strings. But the parser cannot resolve a non-fragment relative reference against a base
+    // with an opaque path (a cannot-be-a-base URL), so it fails with missing-scheme-non-relative-URL.
+    const base = baseURL("foo:opaque");
+
+    for (const input of ["a/b", "/p", "_dmarc.x"]) {
+      assert.equal(isValidURLString(input, { baseURL: base }), true, input);
+
+      const { url, validationErrors } = parseURLWithValidationErrors(input, { baseURL: base });
+      assert.equal(url, null, input);
+      assert.deepStrictEqual(validationErrors, ["missing-scheme-non-relative-URL"], input);
+    }
+
+    // A fragment-only reference does resolve against a cannot-be-a-base URL, so there is no gap there.
+    assert.equal(isValidURLString("#frag", { baseURL: base }), true);
+    assert.notEqual(parseURLWithValidationErrors("#frag", { baseURL: base }).url, null);
+  });
+
+  test("whatwg/url#905 aligns parser validation errors with URL-writing validity", () => {
+    // Each input parses successfully but is not a valid URL string, and the parser now reports a
+    // validation error that matches that invalidity. https://github.com/whatwg/url/pull/905
+    const reportsError = [
+      ["https://exam%70le.org", ["domain-percent-encoded"]], // percent-encoding in a domain
+      ["https://_dmarc.example.com", ["domain-to-ASCII"]], // strict Unicode ToASCII fails
+      ["foo:bar baz", ["invalid-URL-unit"]] // U+0020 SPACE in an opaque path
     ];
 
-    for (const input of cases) {
+    for (const [input, expectedErrors] of reportsError) {
       const { url, validationErrors } = parseURLWithValidationErrors(input);
 
       assert.notEqual(url, null, input);
-      assert.deepStrictEqual(validationErrors, [], input);
+      assert.deepStrictEqual(validationErrors, expectedErrors, input);
       assert.equal(isValidURLString(input), false, input);
     }
+
+    // A non-special scheme followed by an opaque path is now a valid URL string (previously the
+    // leading scheme-like "a:" wrongly made "foo:a:b" invalid).
+    const { url, validationErrors } = parseURLWithValidationErrors("foo:a:b");
+    assert.notEqual(url, null);
+    assert.deepStrictEqual(validationErrors, []);
+    assert.equal(isValidURLString("foo:a:b"), true);
   });
 
-  // "Valid domain" runs the domain parser with beStrict = true, which is stricter than the
-  // non-strict domain parsing the URL parser itself uses. These hosts therefore parse fine but
-  // are not valid URL strings.
+  // Hosts are still parsed with non-strict domain parsing for web compatibility, but strict
+  // domain-to-ASCII failures are validation errors and also make these invalid URL strings.
   test("host strings are validated with strict domain-to-ASCII", () => {
     const invalid = [
       "https://example.com./", // trailing empty label rejected by VerifyDnsLength
@@ -188,7 +216,10 @@ describe("isValidURLString", () => {
     ];
 
     for (const input of invalid) {
-      assert.notEqual(parseURL(input), null, `${input} should still parse`);
+      const { url, validationErrors } = parseURLWithValidationErrors(input);
+
+      assert.notEqual(url, null, `${input} should still parse`);
+      assert.deepStrictEqual(validationErrors, ["domain-to-ASCII"], input);
       assert.equal(isValidURLString(input), false, input);
     }
   });
@@ -279,7 +310,7 @@ describe("isValidURLString", () => {
     assert.equal(isValidURLString("foo://[::1]:80"), true); // opaque hosts may be IPv6
     assert.equal(isValidURLString("foo://h/x"), true);
     assert.equal(isValidURLString("foo://h@x"), false); // "@" is a forbidden host code point
-    assert.equal(isValidURLString("hello:foo:bar"), false); // body begins with a scheme, so not scheme-less
+    assert.equal(isValidURLString("foo://h:8x"), false); // the authority form still requires a valid port
   });
 
   test("fragment and query code points must be URL units", () => {

--- a/test/validation-errors.js
+++ b/test/validation-errors.js
@@ -6,7 +6,7 @@ const { parseURL, parseURLWithValidationErrors } = require("..");
 
 const validationErrorNames = [
   "domain-to-ASCII",
-  "domain-invalid-code-point",
+  "domain-percent-encoded",
   "host-invalid-code-point",
   "IPv4-empty-part",
   "IPv4-too-many-parts",
@@ -46,8 +46,17 @@ const validationErrorTestCases = [
     failure: true
   },
   {
+    // A domain whose strict Unicode ToASCII fails (U+005F) but whose relaxed processing succeeds.
+    input: "https://_dmarc.example.com/",
+    validationErrors: ["domain-to-ASCII"]
+  },
+  {
+    input: "https://exam%70le.org/",
+    validationErrors: ["domain-percent-encoded"]
+  },
+  {
     input: "https://exa%23mple.org",
-    validationErrors: ["domain-invalid-code-point"],
+    validationErrors: ["domain-percent-encoded", "domain-to-ASCII"],
     failure: true
   },
   {
@@ -57,7 +66,7 @@ const validationErrorTestCases = [
   },
   {
     input: "https://127.0.0.1./",
-    validationErrors: ["IPv4-empty-part"]
+    validationErrors: ["domain-to-ASCII", "IPv4-empty-part"]
   },
   {
     input: "https://1.2.3.4.5/",
@@ -134,6 +143,10 @@ const validationErrorTestCases = [
   },
   {
     input: "https://example.org/%s",
+    validationErrors: ["invalid-URL-unit"]
+  },
+  {
+    input: "foo:bar baz", // U+0020 SPACE in an opaque path
     validationErrors: ["invalid-URL-unit"]
   },
   {


### PR DESCRIPTION
Implements the changes proposed in [whatwg/url#905](https://github.com/whatwg/url/pull/905), closing several gaps between the URL writing grammar and the parser; see the commit message for the per-change details. Opened as a draft since that spec PR is still under review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)