### PR TITLE
Handle opaque-path bases in URL string validation

### DIFF
--- a/lib/url-string-validator.js
+++ b/lib/url-string-validator.js
@@ -10,6 +10,7 @@ const {
   isWindowsDriveLetterString,
   p
 } = require("./url-miscellaneous");
+const { hasAnOpaquePath } = require("./url-state-machine");
 
 const pathSegmentExcludedCodePoints = new Set([p("/"), p("?")]);
 const opaquePathExcludedCodePoints = new Set([p("?")]);
@@ -83,8 +84,15 @@ function isValidAbsoluteURLString(input) {
 function isValidRelativeURLWithFragmentString(input, baseURL) {
   const { beforeFragment, fragment } = splitOffFragment(input);
 
-  return (fragment === null || isValidURLFragmentString(fragment)) &&
-    isValidRelativeURLString(beforeFragment, baseURL);
+  if (fragment !== null && !isValidURLFragmentString(fragment)) {
+    return false;
+  }
+
+  if (hasAnOpaquePath(baseURL)) {
+    return beforeFragment === "";
+  }
+
+  return isValidRelativeURLString(beforeFragment, baseURL);
 }
 
 function isValidRelativeURLString(input, baseURL) {

--- a/test/url-string-validator.js
+++ b/test/url-string-validator.js
@@ -152,22 +152,22 @@ describe("isValidURLString", () => {
     }
   });
 
-  test("relative-URL strings can be valid yet unresolvable against a cannot-be-a-base base", () => {
-    // The relative-URL string grammar switches only on the base URL's scheme, so these are valid
-    // URL strings. But the parser cannot resolve a non-fragment relative reference against a base
-    // with an opaque path (a cannot-be-a-base URL), so it fails with missing-scheme-non-relative-URL.
+  test("relative-URL-with-fragment strings with an opaque-path base can only add a fragment", () => {
     const base = baseURL("foo:opaque");
 
-    for (const input of ["a/b", "/p", "_dmarc.x"]) {
-      assert.equal(isValidURLString(input, { baseURL: base }), true, input);
+    assert.equal(isValidURLString("", { baseURL: base }), true);
+    assert.equal(isValidURLString("#frag", { baseURL: base }), true);
+    assert.equal(isValidURLString("#frag%25", { baseURL: base }), true);
+    assert.equal(isValidURLString("#frag%", { baseURL: base }), false);
+
+    for (const input of ["?query", "a/b", "/p", "_dmarc.x", "//example/path"]) {
+      assert.equal(isValidURLString(input, { baseURL: base }), false, input);
 
       const { url, validationErrors } = parseURLWithValidationErrors(input, { baseURL: base });
       assert.equal(url, null, input);
       assert.deepStrictEqual(validationErrors, ["missing-scheme-non-relative-URL"], input);
     }
 
-    // A fragment-only reference does resolve against a cannot-be-a-base URL, so there is no gap there.
-    assert.equal(isValidURLString("#frag", { baseURL: base }), true);
     assert.notEqual(parseURLWithValidationErrors("#frag", { baseURL: base }).url, null);
   });
 


### PR DESCRIPTION
Updates URL string validation to follow whatwg/url#920 for relative strings against opaque-path bases.