### PR TITLE
Reject number-ending domains in URL string validation

### DIFF
--- a/lib/url-miscellaneous.js
+++ b/lib/url-miscellaneous.js
@@ -73,6 +73,69 @@ function domainParserToASCII(domain, beStrict) {
   });
 }
 
+function parseIPv4Number(input, validationErrors = null) {
+  if (input === "") {
+    return failure;
+  }
+
+  let validationErrorSeen = false;
+  let R = 10;
+
+  if (input.length >= 2 && input.charAt(0) === "0" && input.charAt(1).toLowerCase() === "x") {
+    validationErrorSeen = true;
+    input = input.substring(2);
+    R = 16;
+  } else if (input.length >= 2 && input.charAt(0) === "0") {
+    validationErrorSeen = true;
+    input = input.substring(1);
+    R = 8;
+  }
+
+  if (input === "") {
+    validationErrors?.push("IPv4-non-decimal-part");
+    return 0;
+  }
+
+  let regex = /[^0-7]/u;
+  if (R === 10) {
+    regex = /[^0-9]/u;
+  }
+  if (R === 16) {
+    regex = /[^0-9A-Fa-f]/u;
+  }
+
+  if (regex.test(input)) {
+    return failure;
+  }
+
+  if (validationErrorSeen) {
+    validationErrors?.push("IPv4-non-decimal-part");
+  }
+
+  return parseInt(input, R);
+}
+
+function endsInANumber(input) {
+  const parts = input.split(".");
+  if (parts[parts.length - 1] === "") {
+    if (parts.length === 1) {
+      return false;
+    }
+    parts.pop();
+  }
+
+  const last = parts[parts.length - 1];
+  if (/^[0-9]+$/u.test(last)) {
+    return true;
+  }
+
+  if (parseIPv4Number(last) !== failure) {
+    return true;
+  }
+
+  return false;
+}
+
 function domainParser(domain, validationErrors = null, beStrict = false) {
   // A domain-to-ASCII validation error is reported whenever the strict Unicode ToASCII (CheckHyphens,
   // UseSTD3ASCIIRules, and VerifyDnsLength all true) fails, even when the relaxed parameters used
@@ -142,11 +205,13 @@ module.exports = {
   containsPercentEncodedByte,
   defaultPort,
   domainParser,
+  endsInANumber,
   failure,
   forbiddenHostCodePoints,
   isInvalidURLCodePoint,
   isNormalizedWindowsDriveLetterString,
   isPercentEncodedByteAt,
+  parseIPv4Number,
   isSpecialScheme,
   isSpecialSchemeExceptFile,
   isURLCodePoint,

--- a/lib/url-state-machine.js
+++ b/lib/url-state-machine.js
@@ -9,12 +9,14 @@ const {
   containsPercentEncodedByte,
   defaultPort,
   domainParser,
+  endsInANumber,
   failure,
   isInvalidURLCodePoint,
   isNormalizedWindowsDriveLetterString,
   isSpecialScheme,
   isWindowsDriveLetterCodePoints,
   isWindowsDriveLetterString,
+  parseIPv4Number,
   p
 } = require("./url-miscellaneous");
 const { percentDecodeString, utf8PercentEncodeCodePoint, utf8PercentEncodeString,
@@ -67,48 +69,6 @@ function isNotSpecial(url) {
   return !isSpecialScheme(url.scheme);
 }
 
-function parseIPv4Number(input, validationErrors = null) {
-  if (input === "") {
-    return failure;
-  }
-
-  let validationErrorSeen = false;
-  let R = 10;
-
-  if (input.length >= 2 && input.charAt(0) === "0" && input.charAt(1).toLowerCase() === "x") {
-    validationErrorSeen = true;
-    input = input.substring(2);
-    R = 16;
-  } else if (input.length >= 2 && input.charAt(0) === "0") {
-    validationErrorSeen = true;
-    input = input.substring(1);
-    R = 8;
-  }
-
-  if (input === "") {
-    validationErrors?.push("IPv4-non-decimal-part");
-    return 0;
-  }
-
-  let regex = /[^0-7]/u;
-  if (R === 10) {
-    regex = /[^0-9]/u;
-  }
-  if (R === 16) {
-    regex = /[^0-9A-Fa-f]/u;
-  }
-
-  if (regex.test(input)) {
-    return failure;
-  }
-
-  if (validationErrorSeen) {
-    validationErrors?.push("IPv4-non-decimal-part");
-  }
-
-  return parseInt(input, R);
-}
-
 function parseIPv4(input, validationErrors = null) {
   const parts = input.split(".");
   if (parts[parts.length - 1] === "") {
@@ -121,6 +81,10 @@ function parseIPv4(input, validationErrors = null) {
   if (parts.length > 4) {
     validationErrors?.push("IPv4-too-many-parts");
     return failure;
+  }
+
+  if (parts.length < 4) {
+    validationErrors?.push("IPv4-too-few-parts");
   }
 
   const numbers = [];
@@ -372,24 +336,6 @@ function parseHost(input, validationErrors = null, isOpaque = false) {
   }
 
   return asciiDomain;
-}
-
-function endsInANumber(input) {
-  const parts = input.split(".");
-  if (parts[parts.length - 1] === "") {
-    parts.pop();
-  }
-
-  const last = parts[parts.length - 1];
-  if (last !== "" && /^[0-9]+$/u.test(last)) {
-    return true;
-  }
-
-  if (parseIPv4Number(last) !== failure) {
-    return true;
-  }
-
-  return false;
 }
 
 function parseOpaqueHost(input, validationErrors) {

--- a/lib/url-string-validator.js
+++ b/lib/url-string-validator.js
@@ -2,6 +2,7 @@
 
 const {
   domainParser,
+  endsInANumber,
   failure,
   forbiddenHostCodePoints,
   isPercentEncodedByteAt,
@@ -236,7 +237,9 @@ function isValidHostString(input) {
 }
 
 function isValidDomainString(input) {
-  return domainParser(input, null, true) !== failure;
+  const domain = domainParser(input, null, true);
+
+  return domain !== failure && !endsInANumber(domain);
 }
 
 // `isValidIPv4AddressString` and `isValidIPv6AddressString` are transcriptions of the IP-address

--- a/test/url-string-validator.js
+++ b/test/url-string-validator.js
@@ -19,7 +19,6 @@ describe("isValidURLString", () => {
     "https://example.com///this///is///fine.",
     "https://EXAMPLE.com/../x",
     "https://☕.example/",
-    "https://example.255/",
     "https://example/%25?%25#%25",
     "https://[::1]/",
     "https://127.0.0.1/",
@@ -56,6 +55,7 @@ describe("isValidURLString", () => {
     "https://example.com/[]?[]#[]",
     "https://example/%?%#%",
     "https://%30/",
+    "https://example.255/",
     "https://xn--8i7caa/",
     "foo://exa[mple.org"
   ];
@@ -134,22 +134,37 @@ describe("isValidURLString", () => {
     assert.equal(isValidURLString("?q#frag%", { baseURL: base }), false);
   });
 
-  test("URL-writing validity is separate from parser validation errors", () => {
-    // A "valid domain string" only runs the domain parser, so a host that looks like an IPv4
-    // address is grammar-valid even though host parsing later rejects it as a bad IPv4 address.
-    const grammarValidParserInvalid = [
-      ["https://example.255/", ["IPv4-non-numeric-part"]],
+  test("host strings ending in a number must be valid IPv4 addresses", () => {
+    // A host that ends in a number is only valid if it is a valid IPv4 address string.
+    const hostEndingInNumberInvalid = [
+      ["https://example.255/", ["IPv4-too-few-parts", "IPv4-non-numeric-part"]],
       ["https://1.2.3.4.5/", ["IPv4-too-many-parts"]],
       ["https://256.1.1.1/", ["IPv4-out-of-range-part"]]
     ];
 
-    for (const [input, expectedErrors] of grammarValidParserInvalid) {
+    for (const [input, expectedErrors] of hostEndingInNumberInvalid) {
       const { url, validationErrors } = parseURLWithValidationErrors(input);
 
       assert.equal(url, null, input);
       assert.deepStrictEqual(validationErrors, expectedErrors, input);
-      assert.equal(isValidURLString(input), true, input);
+      assert.equal(isValidURLString(input), false, input);
     }
+  });
+
+  test("domain strings must not end in a number", () => {
+    const invalid = [
+      "https://example.1/",
+      "https://example.255/",
+      "https://1.2.3/",
+      "https://1.2.3.4.5/",
+      "https://0x1/"
+    ];
+
+    for (const input of invalid) {
+      assert.equal(isValidURLString(input), false, input);
+    }
+
+    assert.equal(isValidURLString("https://127.0.0.1/"), true);
   });
 
   test("relative-URL-with-fragment strings with an opaque-path base can only add a fragment", () => {

--- a/test/validation-errors.js
+++ b/test/validation-errors.js
@@ -9,6 +9,7 @@ const validationErrorNames = [
   "domain-percent-encoded",
   "host-invalid-code-point",
   "IPv4-empty-part",
+  "IPv4-too-few-parts",
   "IPv4-too-many-parts",
   "IPv4-non-numeric-part",
   "IPv4-non-decimal-part",
@@ -69,13 +70,17 @@ const validationErrorTestCases = [
     validationErrors: ["domain-to-ASCII", "IPv4-empty-part"]
   },
   {
+    input: "https://1.2.3/",
+    validationErrors: ["IPv4-too-few-parts"]
+  },
+  {
     input: "https://1.2.3.4.5/",
     validationErrors: ["IPv4-too-many-parts"],
     failure: true
   },
   {
     input: "https://test.42",
-    validationErrors: ["IPv4-non-numeric-part"],
+    validationErrors: ["IPv4-too-few-parts", "IPv4-non-numeric-part"],
     failure: true
   },
   {


### PR DESCRIPTION
Implements whatwg/url#918 by sharing the parser's ends-in-number check with URL string validation and adding the new IPv4-too-few-parts validation error.