### PR TITLE
Align IPv6 address validation with URL Standard

### DIFF
--- a/lib/url-state-machine.js
+++ b/lib/url-state-machine.js
@@ -292,6 +292,10 @@ function parseIPv6(input, validationErrors = null) {
       return failure;
     }
 
+    if (length > 1 && value < 0x10 ** (length - 1)) {
+      validationErrors?.push("IPv6-piece-leading-zero");
+    }
+
     address[pieceIndex] = value;
     ++pieceIndex;
   }

--- a/lib/url-string-validator.js
+++ b/lib/url-string-validator.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const infra = require("./infra");
 const {
   domainParser,
   failure,
@@ -239,50 +240,28 @@ function isValidDomainString(input) {
   return domainParser(input, null, true) !== failure;
 }
 
-// `isValidIPv4AddressString` and `isValidIPv6AddressString` are transcriptions of the IP-address
-// ABNF in RFC 3986 section 3.2.2 into regular expressions. The URL Standard defines a
-// "valid IPv6-address string" only by reference to the prose in RFC 4291 section 2.2, which has no
-// grammar and is ambiguous about leading zeros and hex letter case
-// (see https://github.com/whatwg/url/issues/916); RFC 3986 is the formal grammar that resolves it:
-//
-//   IPv6address =                            6( h16 ":" ) ls32
-//               /                       "::" 5( h16 ":" ) ls32
-//               / [               h16 ] "::" 4( h16 ":" ) ls32
-//               / [ *1( h16 ":" ) h16 ] "::" 3( h16 ":" ) ls32
-//               / [ *2( h16 ":" ) h16 ] "::" 2( h16 ":" ) ls32
-//               / [ *3( h16 ":" ) h16 ] "::"    h16 ":"   ls32
-//               / [ *4( h16 ":" ) h16 ] "::"              ls32
-//               / [ *5( h16 ":" ) h16 ] "::"              h16
-//               / [ *6( h16 ":" ) h16 ] "::"
-//   ls32        = ( h16 ":" h16 ) / IPv4address
-//   h16         = 1*4HEXDIG
-//   IPv4address = dec-octet "." dec-octet "." dec-octet "." dec-octet
-//   dec-octet   = DIGIT / %x31-39 DIGIT / "1" 2DIGIT / "2" %x30-34 DIGIT / "25" %x30-35
-//
-// So an `h16` field is one to four hex digits of either case with leading zeros allowed, while a
-// `dec-octet` is a shortest 0-255 decimal with leading zeros forbidden. `IPv4address` on its own is
-// exactly a "valid IPv4-address string", and `IPv6address` accepts the same language as the URL
-// Standard's own IPv6 parser.
-const h16 = "[0-9A-Fa-f]{1,4}";
-const decOctet = "(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])";
-const ipv4Address = `${decOctet}(?:\\.${decOctet}){3}`;
-const ls32 = `(?:${h16}:${h16}|${ipv4Address})`;
-const ipv6Alternatives = [
-  `(?:${h16}:){6}${ls32}`,
-  `::(?:${h16}:){5}${ls32}`,
-  `(?:${h16})?::(?:${h16}:){4}${ls32}`,
-  `(?:(?:${h16}:){0,1}${h16})?::(?:${h16}:){3}${ls32}`,
-  `(?:(?:${h16}:){0,2}${h16})?::(?:${h16}:){2}${ls32}`,
-  `(?:(?:${h16}:){0,3}${h16})?::(?:${h16}:){1}${ls32}`,
-  `(?:(?:${h16}:){0,4}${h16})?::${ls32}`,
-  `(?:(?:${h16}:){0,5}${h16})?::${h16}`,
-  `(?:(?:${h16}:){0,6}${h16})?::`
-];
-const ipv4AddressRegExp = new RegExp(`^${ipv4Address}$`, "u");
-const ipv6AddressRegExp = new RegExp(`^(?:${ipv6Alternatives.join("|")})$`, "u");
-
 function isValidIPv4AddressString(input) {
-  return ipv4AddressRegExp.test(input);
+  const pieces = input.split(".");
+
+  return pieces.length === 4 && pieces.every(isValidIPv4AddressPieceString);
+}
+
+function isValidIPv4AddressPieceString(input) {
+  if (input === "" || input.length > 3) {
+    return false;
+  }
+
+  for (let i = 0; i < input.length; ++i) {
+    if (!infra.isASCIIDigit(input.codePointAt(i))) {
+      return false;
+    }
+  }
+
+  if (input.length > 1 && input[0] === "0") {
+    return false;
+  }
+
+  return Number(input) <= 255;
 }
 
 function isValidBracketedIPv6AddressString(input) {
@@ -292,7 +271,103 @@ function isValidBracketedIPv6AddressString(input) {
 }
 
 function isValidIPv6AddressString(input) {
-  return ipv6AddressRegExp.test(input);
+  return getIPv6PiecesStringEffectiveLength(input) === 8 ||
+    getIPv6PiecesAndIPv4StringEffectiveLength(input) === 8 ||
+    isValidCompressedIPv6AddressString(input);
+}
+
+function isValidCompressedIPv6AddressString(input) {
+  const compressionIndex = input.indexOf("::");
+  if (compressionIndex === -1 || compressionIndex !== input.lastIndexOf("::")) {
+    return false;
+  }
+
+  const preceding = input.substring(0, compressionIndex);
+  const following = input.substring(compressionIndex + 2);
+
+  const precedingLength = getOptionalIPv6PiecesStringEffectiveLength(preceding);
+  const followingLength = getOptionalIPv6PiecesOrPiecesAndIPv4StringEffectiveLength(following);
+  if (precedingLength === failure || followingLength === failure) {
+    return false;
+  }
+
+  return precedingLength + followingLength <= 7;
+}
+
+function getOptionalIPv6PiecesStringEffectiveLength(input) {
+  return input === "" ? 0 : getIPv6PiecesStringEffectiveLength(input);
+}
+
+function getOptionalIPv6PiecesOrPiecesAndIPv4StringEffectiveLength(input) {
+  return input === "" ? 0 : getIPv6PiecesOrPiecesAndIPv4StringEffectiveLength(input);
+}
+
+function getIPv6PiecesOrPiecesAndIPv4StringEffectiveLength(input) {
+  if (isValidIPv6PiecesString(input)) {
+    return getIPv6PiecesStringEffectiveLength(input);
+  }
+
+  if (isValidIPv6PiecesAndIPv4String(input)) {
+    return getIPv6PiecesAndIPv4StringEffectiveLength(input);
+  }
+
+  return failure;
+}
+
+function isValidIPv6PiecesAndIPv4String(input) {
+  if (isValidIPv4AddressString(input)) {
+    return true;
+  }
+
+  const ipv4SeparatorIndex = input.lastIndexOf(":");
+  if (ipv4SeparatorIndex === -1) {
+    return false;
+  }
+
+  return isValidIPv6PiecesString(input.substring(0, ipv4SeparatorIndex)) &&
+    isValidIPv4AddressString(input.substring(ipv4SeparatorIndex + 1));
+}
+
+function getIPv6PiecesAndIPv4StringEffectiveLength(input) {
+  if (!isValidIPv6PiecesAndIPv4String(input)) {
+    return failure;
+  }
+
+  const ipv4SeparatorIndex = input.lastIndexOf(":");
+  if (ipv4SeparatorIndex === -1) {
+    return 2;
+  }
+
+  const piecesLength = getIPv6PiecesStringEffectiveLength(input.substring(0, ipv4SeparatorIndex));
+  return piecesLength + 2;
+}
+
+function isValidIPv6PiecesString(input) {
+  if (input === "") {
+    return false;
+  }
+
+  const pieces = input.split(":");
+  return pieces.every(isValidIPv6PieceString);
+}
+
+function getIPv6PiecesStringEffectiveLength(input) {
+  return isValidIPv6PiecesString(input) ? input.split(":").length : failure;
+}
+
+function isValidIPv6PieceString(input) {
+  if (input === "" || input.length > 4) {
+    return false;
+  }
+
+  for (let i = 0; i < input.length; ++i) {
+    if (!infra.isASCIIHex(input.codePointAt(i))) {
+      return false;
+    }
+  }
+
+  const value = parseInt(input, 16);
+  return value <= 0xFFFF && (input.length === 1 || input[0] !== "0");
 }
 
 function isValidOpaqueHostString(input) {

--- a/test/url-string-validator.js
+++ b/test/url-string-validator.js
@@ -52,6 +52,7 @@ describe("isValidURLString", () => {
     "https://example.com:demo",
     "https://example.com:65536",
     "http://[www.example.com]/",
+    "http://[v7.a]/",
     "https://[1:2:3]/",
     "https://example.com/[]?[]#[]",
     "https://example/%?%#%",
@@ -88,7 +89,7 @@ describe("isValidURLString", () => {
     assert.equal(isValidURLString("../path", { baseURL: baseURL("file://server/tmp/") }), true);
   });
 
-  test("IPv6 address strings follow the RFC 4291 text representation forms", () => {
+  test("IPv6 address strings follow the URL Standard text representation forms", () => {
     const valid = [
       "https://[ABCD:EF01:2345:6789:ABCD:EF01:2345:6789]/",
       "https://[2001:DB8:0:0:8:800:200C:417A]/",
@@ -112,6 +113,8 @@ describe("isValidURLString", () => {
       "https://[1::2::3]/",
       "https://[1:2:3:4:5:6:7::8]/",
       "https://[12345::]/",
+      "https://[0DB8::1]/",
+      "https://[::01]/",
       "https://[:1]/",
       "https://[1:]/",
       "https://[::ffff:192.168.000.1]/",
@@ -214,10 +217,9 @@ describe("isValidURLString", () => {
     }
   });
 
-  // Per RFC 4291 §2.2, referenced by the "valid IPv6-address string" definition.
-  test("IPv6 address strings accept the RFC 4291 §2.2 example forms", () => {
+  test("IPv6 address strings accept expanded, compressed, and mixed IPv4 forms", () => {
     const valid = [
-      // Preferred form, expanded forms, and their compressed equivalents.
+      // Expanded and compressed forms.
       "https://[ABCD:EF01:2345:6789:ABCD:EF01:2345:6789]/",
       "https://[FF01:0:0:0:0:0:0:101]/",
       "https://[0:0:0:0:0:0:0:1]/",
@@ -226,16 +228,15 @@ describe("isValidURLString", () => {
       "https://[FF01::101]/",
       "https://[::1]/",
       "https://[::]/",
-      // Mixed IPv4 form, expanded and compressed.
+      // Mixed IPv4 forms.
       "https://[0:0:0:0:0:0:13.1.68.3]/",
       "https://[0:0:0:0:0:FFFF:129.144.52.38]/",
       "https://[::13.1.68.3]/",
       "https://[::FFFF:129.144.52.38]/",
       "https://[1:2:3:4:5:6:1.2.3.4]/",
-      // Leading zeros within a field and mixed-case hex are permitted.
-      "https://[0DB8:0:0:0:0:0:0:1]/",
+      // Mixed-case hex is permitted.
       "https://[abcd:ef01:2345:6789:ABCD:EF01:2345:6789]/",
-      // "::" may compress a single zero group ("one or more groups").
+      // "::" may compress a single zero piece.
       "https://[1:2:3:4:5:6:7::]/",
       "https://[::2:3:4:5:6:7:8]/"
     ];
@@ -246,6 +247,7 @@ describe("isValidURLString", () => {
 
     const invalid = [
       "https://[12345::]/", // field longer than four hex digits
+      "https://[0DB8:0:0:0:0:0:0:1]/", // leading zero in a field
       "https://[1:2:3:4:5:6:7:1.2.3.4]/", // seven hex pieces plus an embedded IPv4 address
       "https://[1:2:3:4:5:6:7:8::]/", // eight pieces leave no group for "::" to compress
       "https://[::13.1.068.3]/", // leading zero in an embedded IPv4 octet

--- a/test/validation-errors.js
+++ b/test/validation-errors.js
@@ -19,6 +19,7 @@ const validationErrorNames = [
   "IPv6-multiple-compression",
   "IPv6-invalid-code-point",
   "IPv6-too-few-pieces",
+  "IPv6-piece-leading-zero",
   "IPv4-in-IPv6-too-many-pieces",
   "IPv4-in-IPv6-invalid-code-point",
   "IPv4-in-IPv6-out-of-range-part",
@@ -113,9 +114,18 @@ const validationErrorTestCases = [
     failure: true
   },
   {
+    input: "http://[v7.a]/",
+    validationErrors: ["IPv6-invalid-code-point"],
+    failure: true
+  },
+  {
     input: "https://[1:2:3]",
     validationErrors: ["IPv6-too-few-pieces"],
     failure: true
+  },
+  {
+    input: "https://[::01]",
+    validationErrors: ["IPv6-piece-leading-zero"]
   },
   {
     input: "https://[1:1:1:1:1:1:1:127.0.0.1]",


### PR DESCRIPTION
Implements the valid IPv6-address string changes from whatwg/url#917 in the URL string validator and parser validation-error reporting.

This replaces the old RFC-derived IPv6 regular expression with helper functions that mirror the URL Standard definitions for valid IPv6 pieces, pieces-and-IPv4 strings, compressed forms, and effective piece length. Valid URL strings now reject IPv6 pieces with leading zeroes, while the parser still accepts them and reports the new `IPv6-piece-leading-zero` validation error.

The tests cover leading-zero IPv6 pieces and an IPvFuture-shaped bracketed host, which RFC 3986 permits but the URL Standard host grammar here rejects.