### PR TITLE
Report IPv4 validation errors for non-ASCII input

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ whatwg-url is a full implementation of the WHATWG [URL Standard](https://url.spe
 
 ## Specification conformance
 
-whatwg-url is currently up to date with the URL spec up to commit [3c83874](https://github.com/whatwg/url/commit/3c83874ae1eac84ceb71d8c4344673251c982bbe).
+whatwg-url is currently up to date with the URL spec up to commit [9dc3827](https://github.com/whatwg/url/commit/9dc3827fc722ac4af3f11061aa3e9adb44a17c8b).
 
 For `file:` URLs, whose [origin is left unspecified](https://url.spec.whatwg.org/#concept-url-origin), whatwg-url chooses to use a new opaque origin (which serializes to `"null"`).
 

--- a/lib/url-state-machine.js
+++ b/lib/url-state-machine.js
@@ -336,6 +336,9 @@ function parseHost(input, validationErrors = null, isOpaque = false) {
   }
 
   if (endsInANumber(asciiDomain)) {
+    if (!infra.isASCIIString(domain)) {
+      validationErrors?.push("IPv4-non-ASCII-input");
+    }
     return parseIPv4(asciiDomain, validationErrors);
   }
 

--- a/test/validation.js
+++ b/test/validation.js
@@ -35,6 +35,7 @@ const validationErrorNames = [
   "IPv4-non-numeric-part",
   "IPv4-non-decimal-part",
   "IPv4-out-of-range-part",
+  "IPv4-non-ASCII-input",
   "IPv6-unclosed",
   "IPv6-invalid-compression",
   "IPv6-too-many-pieces",
@@ -386,6 +387,31 @@ const validationTestCases = [
     validURLString: false,
     parserValidationErrors: ["IPv4-out-of-range-part"],
     parserFailure: true
+  },
+  {
+    input: "https://\u2460.\u2461.\u2462.\u2463",
+    validURLString: false,
+    parserValidationErrors: ["IPv4-non-ASCII-input"]
+  },
+  {
+    input: "https://1\u30022\u30023\u30024",
+    validURLString: false,
+    parserValidationErrors: ["IPv4-non-ASCII-input"]
+  },
+  {
+    input: "https://\u00B2.2.3.4",
+    validURLString: false,
+    parserValidationErrors: ["IPv4-non-ASCII-input"]
+  },
+  {
+    input: "https://\uFF11\uFF12\uFF17.\uFF10.\uFF10.\uFF11",
+    validURLString: false,
+    parserValidationErrors: ["IPv4-non-ASCII-input"]
+  },
+  {
+    input: "https://%E2%91%A0.%E2%91%A1.%E2%91%A2.%E2%91%A3",
+    validURLString: false,
+    parserValidationErrors: ["domain-percent-encoded", "IPv4-non-ASCII-input"]
   },
   { input: "https://exam%70le.org", validURLString: false, parserValidationErrors: ["domain-percent-encoded"] },
   { input: "https://exam%70le.org/", validURLString: false, parserValidationErrors: ["domain-percent-encoded"] },


### PR DESCRIPTION
Reports `IPv4-non-ASCII-input` when IDNA processing maps non-ASCII host input into an IPv4 address, matching the merged URL Standard change.

The validation tests cover circled digits, ideographic dots, superscript digits, fullwidth digits, and percent-encoded non-ASCII host input. The README conformance pointer now references the WHATWG URL commit that merged the spec change.